### PR TITLE
deploy: finished queued timelock to add ALPACA-BNB LPv2 & disabled ALPACA-BNB LPv1 on FL

### DIFF
--- a/.mainnet.json
+++ b/.mainnet.json
@@ -32,7 +32,7 @@
       "allocPoint": 200
     }, {
       "id": 4,
-      "stakingToken": "ALPACA-WBNB LP",
+      "stakingToken": "ALPACA-WBNB LP (Legacy)",
       "address": "0xf3ce6aac24980e6b657926dfc79502ae414d3083",
       "allocPoint": 100
     }, {
@@ -70,6 +70,11 @@
       "stakingToken": "ibALPACA",
       "address": "0xf1bE8ecC990cBcb90e166b71E368299f0116d421",
       "allocPoint": 0
+    }, {
+      "id": 12,
+      "stakingToken": "ALPACA-WBNB LP",
+      "address": "0x1099C2E6Ed6ebA95099c205b599B409305783E43",
+      "allocPoint": 100
     }]
   },
   "Exchanges": {

--- a/.mainnet.json
+++ b/.mainnet.json
@@ -14,67 +14,54 @@
       "id": 0,
       "stakingToken": "debtibBNB",
       "address": "0x5138133f0671071D8b8F1C4c180881bfCfe22CeC",
-      "allocPoint": 0
     }, {
       "id": 1,
       "stakingToken": "ibWBNB",
       "address": "0xd7D069493685A581d27824Fc46EdA46B7EfC0063",
-      "allocPoint": 200
     }, {
       "id": 2,
       "stakingToken": "debtibBUSD",
       "address": "0xD19D6253D979cCF663869fee30b8e0Ac86029ebd",
-      "allocPoint": 0
     }, {
       "id": 3,
       "stakingToken": "ibBUSD",
       "address": "0x7C9e73d4C71dae564d41F78d56439bB4ba87592f",
-      "allocPoint": 200
     }, {
       "id": 4,
       "stakingToken": "ALPACA-WBNB LP (Legacy)",
       "address": "0xf3ce6aac24980e6b657926dfc79502ae414d3083",
-      "allocPoint": 100
     }, {
       "id": 5,
       "stakingToken": "sALPACA",
       "address": "0x6F695Bd5FFD25149176629f8491A5099426Ce7a7",
-      "allocPoint": 84
     }, {
       "id": 6,
       "stakingToken": "debtIbBNB V2",
       "address": "0x6A3487CE84FD83c66B83e598b18412bD1D2A55F9",
-      "allocPoint": 0
     }, {
       "id": 7,
       "stakingToken": "debtIbBUSD V2",
       "address": "0x02dA7035beD00ae645516bDb0c282A7fD4AA7442",
-      "allocPoint": 0
     }, {
       "id": 8,
       "stakingToken": "debtIbETH V2",
       "address": "0x92110af24d280E412b3a89691f6B0B9E09258fe6",
-      "allocPoint": 0
     }, {
       "id": 9,
       "stakingToken": "ibETH",
       "address": "0xbfF4a34A4644a113E8200D7F1D79b3555f723AfE",
-      "allocPoint": 0
     }, {
       "id": 10,
       "stakingToken": "debtIbALPACA V2",
       "address": "0x11362eA137A799298306123EEa014b7809A9DB40",
-      "allocPoint": 0
     }, {
       "id": 11,
       "stakingToken": "ibALPACA",
       "address": "0xf1bE8ecC990cBcb90e166b71E368299f0116d421",
-      "allocPoint": 0
     }, {
       "id": 12,
       "stakingToken": "ALPACA-WBNB LP",
       "address": "0x1099C2E6Ed6ebA95099c205b599B409305783E43",
-      "allocPoint": 100
     }]
   },
   "Exchanges": {

--- a/.testnet.json
+++ b/.testnet.json
@@ -32,7 +32,7 @@
       "allocPoint": 200
     }, {
       "id": 4,
-      "stakingToken": "ALPACA-WBNB LP",
+      "stakingToken": "ALPACA-WBNB LP (Legacy)",
       "address": "0x8aD889FE2eDA1B7CB3a8C09FFB7246571564b379",
       "allocPoint": 100
     }, {
@@ -70,6 +70,11 @@
       "stakingToken": "ibALPACA",
       "address": "0x6ad3A0d891C59677fbbB22E071613253467C382A",
       "allocPoint": 0
+    }, {
+      "id": 13,
+      "stakingToken": "ALPACA-WBNB LP",
+      "address": "0x7549b7d0edcd411e7e5013dc74727f8dab13ab0f",
+      "allocPoint": 100
     }]
   },
   "Exchanges": {

--- a/.testnet.json
+++ b/.testnet.json
@@ -14,67 +14,54 @@
       "id": 0,
       "stakingToken": "debtibBNB",
       "address": "0x897E178C31D86Dbf00982c4F6dB1F5fd9A476964",
-      "allocPoint": 0
     }, {
       "id": 1,
       "stakingToken": "ibWBNB",
       "address": "0xf9d32C5E10Dd51511894b360e6bD39D7573450F9",
-      "allocPoint": 200
     }, {
       "id": 2,
       "stakingToken": "debtibBUSD",
       "address": "0xe6A88866dfeaC58a7BD7fa721C2DfF49501fC791",
-      "allocPoint": 0
     }, {
       "id": 3,
       "stakingToken": "ibBUSD",
       "address": "0xe5ed8148fE4915cE857FC648b9BdEF8Bb9491Fa5",
-      "allocPoint": 200
     }, {
       "id": 4,
       "stakingToken": "ALPACA-WBNB LP (Legacy)",
       "address": "0x8aD889FE2eDA1B7CB3a8C09FFB7246571564b379",
-      "allocPoint": 100
     }, {
       "id": 5,
       "stakingToken": "sALPACA",
       "address": "0x588245DE5E45ecF463565ebD944BBD7975670fAC",
-      "allocPoint": 100
     }, {
       "id": 6,
       "stakingToken": "debtIbBNB V2",
       "address": "0x2E0384Bc38E250639291D6710EDC3d5034e95996",
-      "allocPoint": 0
     }, {
       "id": 7,
       "stakingToken": "debtIbBUSD V2",
       "address": "0x49974bc28f1920A603aa8dffB3C61b4CD5B26710",
-      "allocPoint": 0
     }, {
       "id": 9,
       "stakingToken": "debtIbETH V2",
       "address": "0x5E780a0F887EbeA8425BAa67A834D1168054F645",
-      "allocPoint": 0
     }, {
       "id": 10,
       "stakingToken": "ibETH",
       "address": "0x3F1D4A430C213bd9D4c9a12E4F382270505fCeA1",
-      "allocPoint": 0
     }, {
       "id": 11,
       "stakingToken": "debtIbALPACA V2",
       "address": "0x75d1a708DbC46c4170bD1a176DDCE44D14135Ea8",
-      "allocPoint": 0
     }, {
       "id": 12,
       "stakingToken": "ibALPACA",
       "address": "0x6ad3A0d891C59677fbbB22E071613253467C382A",
-      "allocPoint": 0
     }, {
       "id": 13,
       "stakingToken": "ALPACA-WBNB LP",
       "address": "0x7549b7d0edcd411e7e5013dc74727f8dab13ab0f",
-      "allocPoint": 100
     }]
   },
   "Exchanges": {


### PR DESCRIPTION
## Description
- Update `.mainnet.json` and `.testnet.json` for ALPACA-BNB LPv1 -> ALPACA-BNB LPv2 migration.

## Why?
Because PCSv2
