### PR TITLE
[FIX] Add Reward Info validation

### DIFF
--- a/contracts/6/token/GrazingRange.sol
+++ b/contracts/6/token/GrazingRange.sol
@@ -93,8 +93,8 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     function addRewardInfo(uint256 _campaignID, uint256 _endBlock, uint256 _rewardPerBlock) external onlyOwner {
         RewardInfo[] storage rewardInfo = campaignRewardInfo[_campaignID];
         require(rewardInfo.length < rewardInfoLimit, "GrazingRange::addRewardInfo::reward info length exceeds the limit");
-        uint256 currentEndBlock = _endBlockOf(_campaignID, block.number);
-        require(currentEndBlock < _endBlock, "GrazingRange::addRewardInfo::bad new endblock");
+        require(rewardInfo.length == 0 || rewardInfo[rewardInfo.length - 1].endBlock >= block.number, "GrazingRange::addRewardInfo::reward period ended");
+        require(rewardInfo.length == 0 || rewardInfo[rewardInfo.length - 1].endBlock < _endBlock, "GrazingRange::addRewardInfo::bad new endblock"); 
         rewardInfo.push(RewardInfo({
             endBlock: _endBlock,
             rewardPerBlock: _rewardPerBlock

--- a/test/GrazingRange.test.ts
+++ b/test/GrazingRange.test.ts
@@ -102,13 +102,13 @@ describe('GrazingRange', () => {
       it('should return a current reward info endblock as a current end block', async() => {
         await grazingRangeAsDeployer.addRewardInfo(
           0, 
-          mockedBlock.add(1).toString(),
+          mockedBlock.add(9).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK,
         )
         let currentEndBlock = await grazingRangeAsDeployer.currentEndBlock(
           0
         )
-        expect(currentEndBlock).to.eq(mockedBlock.add(1))
+        expect(currentEndBlock).to.eq(mockedBlock.add(9))
         TimeHelpers.advanceBlockTo(mockedBlock.add(9).toNumber())
 
         await grazingRangeAsDeployer.addRewardInfo(
@@ -138,7 +138,7 @@ describe('GrazingRange', () => {
         let lbm = await TimeHelpers.latestBlockNumber()
         await grazingRangeAsDeployer.addRewardInfo(
           0, 
-          mockedBlock.add(1).toString(),
+          mockedBlock.add(9).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK,
         )
         let currentRewardPerBlock = await grazingRangeAsDeployer.currentRewardPerBlock(
@@ -247,6 +247,24 @@ describe('GrazingRange', () => {
             mockedBlock.add(1).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
           )).to.be.revertedWith('GrazingRange::addRewardInfo::bad new endblock')
+        })
+      })
+      context('Whenthe current reward period has ended', async () => {
+        it('should reverted with the message GrazingRange::addRewardInfo::reward period ended', async() => {
+          // add the first reward info
+          // with block number + 1
+          await grazingRangeAsDeployer.addRewardInfo(
+            0, 
+            mockedBlock.toString(),
+            INITIAL_BONUS_REWARD_PER_BLOCK,
+          )
+          console.log(await (await TimeHelpers.latestBlockNumber()).toString(), mockedBlock.toString())
+          //this called method is invoked on blockNumber + 3
+          await expect(grazingRangeAsDeployer.addRewardInfo(
+            0, 
+            mockedBlock.add(1).toString(),
+            INITIAL_BONUS_REWARD_PER_BLOCK,
+          )).to.be.revertedWith('GrazingRange::addRewardInfo::reward period ended')
         })
       })
     })


### PR DESCRIPTION


<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
This is a bugfix pr for fixing add reward info validation as well as adding the new validation

## Why?
- for replacing currentEndBlock with rewardInfo[rewardInfo.length -1].endBlock, if the pushed rewardInfo's endblocks are [1,2,3,4,5] and current blocknumber is 3 and newly added endblock is 4, the validation will be passed. By changing the validation to  rewardInfo[rewardInfo.length -1].endBlock, if newly added endblock is 4, the function will be reverted since the latest end block is 5 and 5 > 4

## ChangeLogs:
- replace current End Block with the last end block as an end block validation
- add reward period validation, if the last reward period has ended, can't add more

