### PR TITLE
[FIX] Grazing Range findings

### DIFF
--- a/contracts/6.12/GrazingRange.sol
+++ b/contracts/6.12/GrazingRange.sol
@@ -94,7 +94,7 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     }
 
     // @notice if the new reward info is added, the reward & its end block will be extended by the newly pushed reward info.
-    function addRewardInfo(uint256 _campaignID, uint256 _endBlock, uint256 _rewardPerBlock, address _sourceOfFund) external onlyOwner {
+    function addRewardInfo(address _sourceOfFund, uint256 _campaignID, uint256 _endBlock, uint256 _rewardPerBlock) external onlyOwner {
         RewardInfo[] storage rewardInfo = campaignRewardInfo[_campaignID];
         CampaignInfo storage campaign = campaignInfo[_campaignID];
         require(rewardInfo.length < rewardInfoLimit, "GrazingRange::addRewardInfo::reward info length exceeds the limit");

--- a/contracts/6.12/GrazingRange.sol
+++ b/contracts/6.12/GrazingRange.sol
@@ -65,6 +65,7 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     event EmergencyWithdraw(address indexed user, uint256 amount, uint256 campaign);
     event AddCampaignInfo(uint256 indexed campaignID, IERC20 stakingToken, IERC20 rewardToken, uint256 startBlock);
     event AddRewardInfo(uint256 indexed campaignID, uint256 indexed phase, uint256 endBlock, uint256 rewardPerBlock);
+    event SetRewardInfoLimit(uint256 rewardInfoLimit);
 
     function initialize() external initializer {
         OwnableUpgradeSafe.__Ownable_init();
@@ -75,6 +76,7 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     // @notice set new reward info limit
     function setRewardInfoLimit(uint256 _updatedRewardInfoLimit) external onlyOwner {
         rewardInfoLimit = _updatedRewardInfoLimit;
+        emit SetRewardInfoLimit(rewardInfoLimit);
     }
 
     // @notice reward campaign, one campaign represents a pair of staking and reward token, last reward Block and acc reward Per Share

--- a/deploy/s018_timelock_add_rewardInfos_to_grazing_range.ts
+++ b/deploy/s018_timelock_add_rewardInfos_to_grazing_range.ts
@@ -5,6 +5,7 @@ import { Timelock__factory } from '../typechain'
 
 interface IAddGrazingRangeRewardInfoParam {
     PHASE_NAME: string
+    SOURCE_OF_FUND: string
     CAMPAIGN_ID: string
     ENDBLOCK: string
     REWARD_PER_BLOCK: string
@@ -27,6 +28,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const EXACT_ETA = '1619703660';
   const REWARDINFO: IAddGrazingRangeRewardInfoParamList = [{
     PHASE_NAME: 'PHASE_1',
+    SOURCE_OF_FUND: '',
     CAMPAIGN_ID: '2',
     ENDBLOCK: '8405700',
     REWARD_PER_BLOCK: ethers.utils.parseEther('1000').toString()
@@ -50,10 +52,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log(`>> Timelock: Adding a grazing range's reward info: "${rewardInfo.PHASE_NAME}" via Timelock`);
     await timelock.queueTransaction(
         GRAZING_RANGE, '0',
-        'addRewardInfo(uint256,uint256,uint256)',
+        'addRewardInfo(uint256,uint256,uint256,uint256)',
         ethers.utils.defaultAbiCoder.encode(
-            ['uint256', 'uint256', 'uint256'],
+            ['uint256','uint256', 'uint256', 'uint256'],
             [
+                rewardInfo.SOURCE_OF_FUND,
                 rewardInfo.CAMPAIGN_ID,
                 rewardInfo.ENDBLOCK,
                 rewardInfo.REWARD_PER_BLOCK,
@@ -61,7 +64,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         ), EXACT_ETA
     );
     console.log("generate timelock.executeTransaction:")
-    console.log(`await timelock.executeTransaction('${GRAZING_RANGE}', '0', 'addRewardInfo(uint256,uint256,uint256)', ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256', 'uint256'],['${rewardInfo.CAMPAIGN_ID}','${rewardInfo.ENDBLOCK}','${rewardInfo.REWARD_PER_BLOCK}']), ${EXACT_ETA})`)
+    console.log(`await timelock.executeTransaction('${GRAZING_RANGE}', '0', 'addRewardInfo(uint256,uint256,uint256,uint256)', ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256', 'uint256', 'uint256'],['${rewardInfo.SOURCE_OF_FUND}','${rewardInfo.CAMPAIGN_ID}','${rewardInfo.ENDBLOCK}','${rewardInfo.REWARD_PER_BLOCK}']), ${EXACT_ETA})`)
     console.log("✅ Done");
   }
 };

--- a/hardhat.config.6.12.ts
+++ b/hardhat.config.6.12.ts
@@ -1,0 +1,88 @@
+import { config as dotEnvConfig } from "dotenv";
+dotEnvConfig();
+
+import "@openzeppelin/hardhat-upgrades";
+
+import "@nomiclabs/hardhat-waffle";
+import "hardhat-typechain";
+import "hardhat-deploy";
+import "solidity-coverage";
+
+module.exports = {
+  defaultNetwork: 'hardhat',
+  networks: {
+    hardhat: {
+      chainId: 31337,
+      gas: 12000000,
+      blockGasLimit: 0x1fffffffffffff,
+      allowUnlimitedContractSize: true,
+      timeout: 1800000,
+      accounts: [
+        {
+          privateKey: process.env.LOCAL_PRIVATE_KEY_1,
+          balance: '10000000000000000000000',
+        },
+        {
+          privateKey: process.env.LOCAL_PRIVATE_KEY_2,
+          balance: '10000000000000000000000',
+        },
+        {
+          privateKey: process.env.LOCAL_PRIVATE_KEY_3,
+          balance: '10000000000000000000000',
+        },
+        {
+          privateKey: process.env.LOCAL_PRIVATE_KEY_4,
+          balance: '10000000000000000000000',
+        },
+      ],
+    },
+    testnet: {
+      url: 'https://data-seed-prebsc-1-s3.binance.org:8545',
+      accounts: [process.env.BSC_TESTNET_PRIVATE_KEY],
+    },
+    mainnet: {
+      url: 'https://bsc-dataseed3.ninicoin.io',
+      accounts: [process.env.BSC_MAINNET_PRIVATE_KEY],
+    },
+  },
+  namedAccounts: {
+    deployer: {
+      default: 0,
+    },
+  },
+  solidity: {
+    version: '0.6.12',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 1,
+      },
+      evmVersion: "istanbul",
+      outputSelection: {
+        "*": {
+          "": [
+            "ast"
+          ],
+          "*": [
+            "evm.bytecode.object",
+            "evm.deployedBytecode.object",
+            "abi",
+            "evm.bytecode.sourceMap",
+            "evm.deployedBytecode.sourceMap",
+            "metadata"
+          ]
+        }
+      },
+    },
+  },
+  paths: {
+    sources: './contracts/6.12',
+    tests: './test',
+    cache: './cache',
+    artifacts: './artifacts',
+  },
+  typechain: {
+    outDir: './typechain',
+    target: process.env.TYPECHAIN_TARGET || 'ethers-v5',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "compile5": "hardhat typechain --config hardhat.config.5.ts",
     "compile6": "hardhat typechain --config hardhat.config.ts",
-    "compile6:12": "hardhat typechain --config hardhat.config.6.12.ts",
+    "compile6.12": "hardhat typechain --config hardhat.config.6.12.ts",
     "compile": "hardhat typechain --config hardhat.config.ts && hardhat typechain --config hardhat.config.5.ts && hardhat typechain --config hardhat.config.6.12.ts",
     "deploy:mainnet:001": "hardhat --network mainnet deploy --no-compile --reset --tags TimeLock",
     "deploy:mainnet:002": "hardhat --network mainnet deploy --no-compile --reset --tags FairLaunch",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "compile5": "hardhat typechain --config hardhat.config.5.ts",
     "compile6": "hardhat typechain --config hardhat.config.ts",
-    "compile": "hardhat typechain --config hardhat.config.ts && hardhat typechain --config hardhat.config.5.ts",
+    "compile6:12": "hardhat typechain --config hardhat.config.6.12.ts",
+    "compile": "hardhat typechain --config hardhat.config.ts && hardhat typechain --config hardhat.config.5.ts && hardhat typechain --config hardhat.config.6.12.ts",
     "deploy:mainnet:001": "hardhat --network mainnet deploy --no-compile --reset --tags TimeLock",
     "deploy:mainnet:002": "hardhat --network mainnet deploy --no-compile --reset --tags FairLaunch",
     "deploy:mainnet:003": "hardhat --network mainnet deploy --no-compile --reset --tags ShareStrategies",

--- a/test/GrazingRange.test.ts
+++ b/test/GrazingRange.test.ts
@@ -323,6 +323,24 @@ describe('GrazingRange', () => {
           )).to.be.revertedWith('GrazingRange::addRewardInfo::reward info length exceeds the limit')
         })
       })
+      context('When the newly added reward info endblock is less that the start block', async () => {
+        it('should be reverted', async() => {
+          const mintedReward = INITIAL_BONUS_REWARD_PER_BLOCK.mul(mockedBlock.add(11).sub(mockedBlock.add(8)))
+          await rewardTokenAsDeployer.mint(await deployer.getAddress(), mintedReward)
+          await grazingRangeAsDeployer.addCampaignInfo(
+            stakingToken.address, 
+            rewardToken.address, 
+            mockedBlock.add(8).toString(),
+          )
+          // add the first reward info
+          await expect(grazingRangeAsDeployer.addRewardInfo(
+            0, 
+            mockedBlock.sub(1).toString(),
+            INITIAL_BONUS_REWARD_PER_BLOCK,
+            await deployer.getAddress()
+          )).to.reverted
+        })
+      })
       context('When newly added reward info endblock is less than current end block', async() => {
         it('should reverted with the message GrazingRange::addRewardInfo::bad new endblock', async() => {
           const mintedReward = INITIAL_BONUS_REWARD_PER_BLOCK.mul(mockedBlock.add(11).sub(mockedBlock.add(8)))

--- a/test/GrazingRange.test.ts
+++ b/test/GrazingRange.test.ts
@@ -114,10 +114,10 @@ describe('GrazingRange', () => {
           mockedBlock.add(8).toString(),
         )
         await grazingRangeAsDeployer.addRewardInfo(
+          await deployer.getAddress(),
           0, 
           mockedBlock.add(9).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK,
-          await deployer.getAddress()
         )
         let currentEndBlock = await grazingRangeAsDeployer.currentEndBlock(
           0
@@ -126,10 +126,10 @@ describe('GrazingRange', () => {
         TimeHelpers.advanceBlockTo(mockedBlock.add(9).toNumber())
 
         await grazingRangeAsDeployer.addRewardInfo(
+          await deployer.getAddress(),
           0, 
           mockedBlock.add(10).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK,
-          await deployer.getAddress()
         )
         currentEndBlock = await grazingRangeAsDeployer.currentEndBlock(
           0
@@ -160,10 +160,10 @@ describe('GrazingRange', () => {
           mockedBlock.add(8).toString(),
         )
         await grazingRangeAsDeployer.addRewardInfo(
+          await deployer.getAddress(),
           0,
           mockedBlock.add(9).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK,
-          await deployer.getAddress()
         )
         let currentRewardPerBlock = await grazingRangeAsDeployer.currentRewardPerBlock(
           0
@@ -172,10 +172,10 @@ describe('GrazingRange', () => {
 
         await TimeHelpers.advanceBlockTo(mockedBlock.add(8).toNumber())
         await grazingRangeAsDeployer.addRewardInfo(
+          await deployer.getAddress(),
           0, 
           mockedBlock.add(10).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('500')),
-          await deployer.getAddress()
         )
         await TimeHelpers.advanceBlockTo(mockedBlock.add(10).toNumber())
         currentRewardPerBlock = await grazingRangeAsDeployer.currentRewardPerBlock(
@@ -196,10 +196,10 @@ describe('GrazingRange', () => {
           mockedBlock.add(8).toString(),
         )
         await grazingRangeAsDeployer.addRewardInfo(
+          await deployer.getAddress(),
           0,
           mockedBlock.add(9).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK,
-          await deployer.getAddress()
         )
         let currentRewardPerBlock = await grazingRangeAsDeployer.currentRewardPerBlock(
           0
@@ -208,10 +208,10 @@ describe('GrazingRange', () => {
 
         await TimeHelpers.advanceBlockTo(mockedBlock.add(8).toNumber())
         await grazingRangeAsDeployer.addRewardInfo(
+          await deployer.getAddress(),
           0, 
           mockedBlock.add(10).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('500')),
-          await deployer.getAddress()
         )
         await TimeHelpers.advanceBlockTo(mockedBlock.add(100).toNumber())
         currentRewardPerBlock = await grazingRangeAsDeployer.currentRewardPerBlock(
@@ -255,19 +255,19 @@ describe('GrazingRange', () => {
           expect(length).to.eq(0)
           // add the first reward info
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(11).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
           length = await grazingRangeAsDeployer.rewardInfoLen(0)
           expect(length).to.eq(1)
 
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(20).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK.add(1),
-            await deployer.getAddress()
           )
           const rewardInfo = (await grazingRangeAsDeployer.campaignRewardInfo(0, 1))
           length = await grazingRangeAsDeployer.rewardInfoLen(0)
@@ -290,10 +290,10 @@ describe('GrazingRange', () => {
           // set reward info limit to 1
           await expect(grazingRangeAsAlice.setRewardInfoLimit(1)).to.be.reverted
           await expect(grazingRangeAsAlice.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(11).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )).to.be.reverted
         })
       })
@@ -310,16 +310,16 @@ describe('GrazingRange', () => {
           await grazingRangeAsDeployer.setRewardInfoLimit(1)
           // add the first reward info
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(11).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
           await expect(grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(11).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )).to.be.revertedWith('GrazingRange::addRewardInfo::reward info length exceeds the limit')
         })
       })
@@ -334,10 +334,10 @@ describe('GrazingRange', () => {
           )
           // add the first reward info
           await expect(grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.sub(1).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )).to.reverted
         })
       })
@@ -352,16 +352,16 @@ describe('GrazingRange', () => {
           )
           // add the first reward info
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(11).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
           await expect(grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(1).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )).to.be.revertedWith('GrazingRange::addRewardInfo::bad new endblock')
         })
       })
@@ -379,18 +379,18 @@ describe('GrazingRange', () => {
           // add the first reward info
           // with block number + 10
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(10).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
           await TimeHelpers.advanceBlockTo(mockedBlock.add(11).toNumber())
           //this called method is invoked on blockNumber + 12
           await expect(grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(12).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )).to.be.revertedWith('GrazingRange::addRewardInfo::reward period ended')
         })
       })
@@ -424,10 +424,10 @@ describe('GrazingRange', () => {
           )
 
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(11).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
           // mint staking token to alice
           await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -457,10 +457,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(16).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('300'))
@@ -508,10 +508,10 @@ describe('GrazingRange', () => {
                     )
           
                     await grazingRangeAsDeployer.addRewardInfo(
+                      await deployer.getAddress(),
                       0, 
                       mockedBlock.add(18).toString(),
                       INITIAL_BONUS_REWARD_PER_BLOCK,
-                      await deployer.getAddress()
                     )
                     // mint staking token to alice
                     await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -551,10 +551,10 @@ describe('GrazingRange', () => {
                     )
           
                     await grazingRangeAsDeployer.addRewardInfo(
+                      await deployer.getAddress(),
                       0, 
                       mockedBlock.add(18).toString(),
                       INITIAL_BONUS_REWARD_PER_BLOCK,
-                      await deployer.getAddress()
                     )
                     // mint staking token to alice
                     await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -591,10 +591,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(8).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -631,10 +631,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(8).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -672,10 +672,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(8).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -714,10 +714,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(11).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -772,17 +772,17 @@ describe('GrazingRange', () => {
               )
     
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(12).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
 
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(21).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')), // 200 reward per block
-                await deployer.getAddress()
               )
               // mint staking token to alice
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -825,17 +825,17 @@ describe('GrazingRange', () => {
               )
     
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(11).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
 
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(21).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')), // 200 reward per block
-                await deployer.getAddress()
               )
               // mint staking token to alice
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -889,18 +889,18 @@ describe('GrazingRange', () => {
 
           // set reward for campaign 0
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(13).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
 
           // set reward for campaign 1
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             1, 
             mockedBlock.add(17).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')),
-            await deployer.getAddress()
           )
           // mint staking token to alice
           await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('1000'))
@@ -960,10 +960,10 @@ describe('GrazingRange', () => {
         )
 
         await grazingRangeAsDeployer.addRewardInfo(
+          await deployer.getAddress(),
           0, 
           mockedBlock.add(10).toString(),
           INITIAL_BONUS_REWARD_PER_BLOCK,
-          await deployer.getAddress()
         )
         // mint staking token to alice
         await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -988,10 +988,10 @@ describe('GrazingRange', () => {
       )
 
       await grazingRangeAsDeployer.addRewardInfo(
+        await deployer.getAddress(),
         0, 
         mockedBlock.add(10).toString(),
         INITIAL_BONUS_REWARD_PER_BLOCK,
-        await deployer.getAddress()
       )
       // mint staking token to alice
       await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1050,16 +1050,16 @@ describe('GrazingRange', () => {
                 mockedBlock.add(5).toString(),
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(10).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 1, 
                 mockedBlock.add(20).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               // emergency withdraw campaign 0 with all minted reward
               // should revert, since, even though it shares the same reward token, still different in terms of campaign's all reward token
@@ -1084,16 +1084,16 @@ describe('GrazingRange', () => {
                 mockedBlock.add(5).toString(),
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(10).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 1, 
                 mockedBlock.add(20).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('400'))
               await stakingTokenAsAlice.approve(grazingRange.address, ethers.utils.parseEther('400'))
@@ -1123,16 +1123,16 @@ describe('GrazingRange', () => {
                 mockedBlock.add(5).toString(),
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(10).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 1, 
                 mockedBlock.add(20).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await expect(grazingRangeAsDeployer.emergencyRewardWithdraw(BigNumber.from(0), ethers.utils.parseEther('600'), await deployer.getAddress())).to.revertedWith("GrazingRange::emergencyRewardWithdraw::not enough reward token")
               
@@ -1156,16 +1156,16 @@ describe('GrazingRange', () => {
                 mockedBlock.add(5).toString(),
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(10).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 1, 
                 mockedBlock.add(20).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('400'))
               await stakingTokenAsAlice.approve(grazingRange.address, ethers.utils.parseEther('400'))
@@ -1197,16 +1197,16 @@ describe('GrazingRange', () => {
                 mockedBlock.add(5).toString(),
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(11).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 1, 
                 mockedBlock.add(20).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               const aliceAsBeneficiary = await alice.getAddress()
               // emergency withdraw campaign 0
@@ -1242,16 +1242,16 @@ describe('GrazingRange', () => {
                 mockedBlock.add(5).toString(),
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(11).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 1, 
                 mockedBlock.add(20).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('400'))
               await stakingTokenAsAlice.approve(grazingRange.address, ethers.utils.parseEther('400'))
@@ -1296,16 +1296,16 @@ describe('GrazingRange', () => {
                 mockedBlock.add(5).toString(),
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(11).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 1, 
                 mockedBlock.add(20).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               const aliceAsBeneficiary = await alice.getAddress()
               // emergency withdraw campaign 0
@@ -1341,16 +1341,16 @@ describe('GrazingRange', () => {
                 mockedBlock.add(5).toString(),
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(12).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 1, 
                 mockedBlock.add(20).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('400'))
               await stakingTokenAsAlice.approve(grazingRange.address, ethers.utils.parseEther('400'))
@@ -1404,10 +1404,10 @@ describe('GrazingRange', () => {
           )
 
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(11).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
           // mint staking token to alice
           await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1437,10 +1437,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(8).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1472,10 +1472,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(8).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1510,10 +1510,10 @@ describe('GrazingRange', () => {
                 )
       
                 await grazingRangeAsDeployer.addRewardInfo(
+                  await deployer.getAddress(),
                   0, 
                   mockedBlock.add(10).toString(),
                   INITIAL_BONUS_REWARD_PER_BLOCK,
-                  await deployer.getAddress()
                 )
                 // mint staking token to alice
                 await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1546,10 +1546,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(11).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1582,10 +1582,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(10).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1628,17 +1628,17 @@ describe('GrazingRange', () => {
               )
     
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(11).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
 
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(21).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')), // 200 reward per block
-                await deployer.getAddress()
               )
               // mint staking token to alice
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1690,17 +1690,17 @@ describe('GrazingRange', () => {
               )
     
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(11).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
 
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(21).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')), // 200 reward per block
-                await deployer.getAddress()
               )
               // mint staking token to alice
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1766,18 +1766,18 @@ describe('GrazingRange', () => {
 
           // set reward for campaign 0
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(13).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
 
           // set reward for campaign 1
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             1, 
             mockedBlock.add(21).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')),
-            await deployer.getAddress()
           )
           // mint staking token to alice
           await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('1000'))
@@ -1871,10 +1871,10 @@ describe('GrazingRange', () => {
           )
 
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(11).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
           // mint staking token to alice
           await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1905,10 +1905,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(8).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1941,10 +1941,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(8).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -1978,10 +1978,10 @@ describe('GrazingRange', () => {
                 )
       
                 await grazingRangeAsDeployer.addRewardInfo(
+                  await deployer.getAddress(),
                   0, 
                   mockedBlock.add(10).toString(),
                   INITIAL_BONUS_REWARD_PER_BLOCK,
-                  await deployer.getAddress()
                 )
                 // mint staking token to alice
                 await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -2014,10 +2014,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(11).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -2050,10 +2050,10 @@ describe('GrazingRange', () => {
                   )
         
                   await grazingRangeAsDeployer.addRewardInfo(
+                    await deployer.getAddress(),
                     0, 
                     mockedBlock.add(10).toString(),
                     INITIAL_BONUS_REWARD_PER_BLOCK,
-                    await deployer.getAddress()
                   )
                   // mint staking token to alice
                   await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -2095,17 +2095,17 @@ describe('GrazingRange', () => {
               )
     
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(11).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
 
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(21).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')), // 200 reward per block
-                await deployer.getAddress()
               )
               // mint staking token to alice
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -2154,17 +2154,17 @@ describe('GrazingRange', () => {
               )
     
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(11).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK,
-                await deployer.getAddress()
               )
 
               await grazingRangeAsDeployer.addRewardInfo(
+                await deployer.getAddress(),
                 0, 
                 mockedBlock.add(21).toString(),
                 INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')), // 200 reward per block
-                await deployer.getAddress()
               )
               // mint staking token to alice
               await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('100'))
@@ -2228,18 +2228,18 @@ describe('GrazingRange', () => {
 
           // set reward for campaign 0
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             0, 
             mockedBlock.add(13).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK,
-            await deployer.getAddress()
           )
 
           // set reward for campaign 1
           await grazingRangeAsDeployer.addRewardInfo(
+            await deployer.getAddress(),
             1, 
             mockedBlock.add(21).toString(),
             INITIAL_BONUS_REWARD_PER_BLOCK.add(ethers.utils.parseEther('100')),
-            await deployer.getAddress()
           )
           // mint staking token to alice
           await stakingTokenAsDeployer.mint(await alice.getAddress(), ethers.utils.parseEther('1000'))


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
This is a patch PR for fixing some grazing range's findings 

## Why?
Some improvement, bugfixes are needed in order to let the user/owner seamlessly interact with the contract.

## ChangeLogs:
- upgrade solidity version from 0.6.6 to 0.6.12
- fix `_rewardBlockOf` method, when the current timeblock exceed the end timeblock, return 0
- adding more logic in `addRewardInfo` and `emergencyRewardWithdraw `in order to be able to validate when multiple campaigns share the same `rewardToken`, by adding the field called `totalRewards`, when `addRewardInfo`, `totalRewards` will be accumulated, based on `range * rewardPerBlock`, once the owner call emergency reward withdraw, replacing campaign.rewardToken.balanceOf(address(this)) with  campaign.totalRewards can solve this issue
- add more event called SetRewardInfoLimit, will be emitted whenever the owner set the new reward info limit