### PR TITLE
[REFACTOR] Remove source of fund and change to reward holder

### DIFF
--- a/contracts/6.12/GrazingRange.sol
+++ b/contracts/6.12/GrazingRange.sol
@@ -71,7 +71,7 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     event SetRewardHolder(address rewardHolder);
 
     /**
-     * @dev Throws if called by any account other than the owner.
+     * @dev Throws if called by any account other than the reward holder.
      */
     modifier onlyRewardHolder() {
         require(rewardHolder == msg.sender, "GrazingRange::onlyRewardHolder::caller is not a reward holder");
@@ -85,7 +85,7 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
         rewardHolder = _rewardHolder;
     }
 
-    // @notice function for setting a reward holder who is responsible for adding reward info
+    // @notice function for setting a reward holder who is responsible for adding a reward info
     function setRewardHolder(address _rewardHolder) external onlyOwner {
         rewardHolder = _rewardHolder;
         emit SetRewardHolder(_rewardHolder);

--- a/contracts/6.12/GrazingRange.sol
+++ b/contracts/6.12/GrazingRange.sol
@@ -59,6 +59,8 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     // @notice limit length of reward info
     // how many phases are allowed
     uint256 public rewardInfoLimit;
+    // @dev reward holder account
+    address public rewardHolder;
 
     event Deposit(address indexed user, uint256 amount, uint256 campaign);
     event Withdraw(address indexed user, uint256 amount, uint256 campaign);
@@ -66,11 +68,27 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     event AddCampaignInfo(uint256 indexed campaignID, IERC20 stakingToken, IERC20 rewardToken, uint256 startBlock);
     event AddRewardInfo(uint256 indexed campaignID, uint256 indexed phase, uint256 endBlock, uint256 rewardPerBlock);
     event SetRewardInfoLimit(uint256 rewardInfoLimit);
+    event SetRewardHolder(address rewardHolder);
 
-    function initialize() external initializer {
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyRewardHolder() {
+        require(rewardHolder == msg.sender, "GrazingRange::onlyRewardHolder::caller is not a reward holder");
+        _;
+    }
+
+    function initialize(address _rewardHolder) external initializer {
         OwnableUpgradeSafe.__Ownable_init();
         ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
         rewardInfoLimit = 52; // 52 weeks, 1 year
+        rewardHolder = _rewardHolder;
+    }
+
+    // @notice function for setting a reward holder who is responsible for adding reward info
+    function setRewardHolder(address _rewardHolder) external onlyOwner {
+        rewardHolder = _rewardHolder;
+        emit SetRewardHolder(_rewardHolder);
     }
 
     // @notice set new reward info limit
@@ -94,7 +112,7 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     }
 
     // @notice if the new reward info is added, the reward & its end block will be extended by the newly pushed reward info.
-    function addRewardInfo(address _sourceOfFund, uint256 _campaignID, uint256 _endBlock, uint256 _rewardPerBlock) external onlyOwner {
+    function addRewardInfo(uint256 _campaignID, uint256 _endBlock, uint256 _rewardPerBlock) external onlyRewardHolder {
         RewardInfo[] storage rewardInfo = campaignRewardInfo[_campaignID];
         CampaignInfo storage campaign = campaignInfo[_campaignID];
         require(rewardInfo.length < rewardInfoLimit, "GrazingRange::addRewardInfo::reward info length exceeds the limit");
@@ -103,7 +121,7 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
         uint256 startBlock = rewardInfo.length == 0 ?  campaign.startBlock : rewardInfo[rewardInfo.length - 1].endBlock;
         uint256 blockRange = _endBlock.sub(startBlock);
         uint256 totalRewards = _rewardPerBlock.mul(blockRange);
-        campaign.rewardToken.safeTransferFrom(address(_sourceOfFund), address(this), totalRewards);
+        campaign.rewardToken.safeTransferFrom(rewardHolder, address(this), totalRewards);
         campaign.totalRewards = campaign.totalRewards.add(totalRewards);
         rewardInfo.push(RewardInfo({
             endBlock: _endBlock,

--- a/contracts/6.12/GrazingRange.sol
+++ b/contracts/6.12/GrazingRange.sol
@@ -70,14 +70,6 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     event SetRewardInfoLimit(uint256 rewardInfoLimit);
     event SetRewardHolder(address rewardHolder);
 
-    /**
-     * @dev Throws if called by any account other than the reward holder.
-     */
-    modifier onlyRewardHolder() {
-        require(rewardHolder == msg.sender, "GrazingRange::onlyRewardHolder::caller is not a reward holder");
-        _;
-    }
-
     function initialize(address _rewardHolder) external initializer {
         OwnableUpgradeSafe.__Ownable_init();
         ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
@@ -112,7 +104,7 @@ contract GrazingRange is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe  {
     }
 
     // @notice if the new reward info is added, the reward & its end block will be extended by the newly pushed reward info.
-    function addRewardInfo(uint256 _campaignID, uint256 _endBlock, uint256 _rewardPerBlock) external onlyRewardHolder {
+    function addRewardInfo(uint256 _campaignID, uint256 _endBlock, uint256 _rewardPerBlock) external onlyOwner {
         RewardInfo[] storage rewardInfo = campaignRewardInfo[_campaignID];
         CampaignInfo storage campaign = campaignInfo[_campaignID];
         require(rewardInfo.length < rewardInfoLimit, "GrazingRange::addRewardInfo::reward info length exceeds the limit");

--- a/deploy/021_deploy_grazingRange.ts
+++ b/deploy/021_deploy_grazingRange.ts
@@ -17,7 +17,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   Check all variables below before execute the deployment script
   */
 
-
+  const REWARD_HOLDER = ''
 
 
 
@@ -28,7 +28,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     (await ethers.getSigners())[0]
   )) as GrazingRange__factory;
   const grazingRange = await upgrades.deployProxy(
-    GrazingRange
+    GrazingRange,
+    [REWARD_HOLDER]
   ) as GrazingRange;
   await grazingRange.deployed();
   console.log(`>> Deployed at ${grazingRange.address}`);

--- a/deploy/s018_timelock_add_rewardInfos_to_grazing_range.ts
+++ b/deploy/s018_timelock_add_rewardInfos_to_grazing_range.ts
@@ -5,7 +5,6 @@ import { Timelock__factory } from '../typechain'
 
 interface IAddGrazingRangeRewardInfoParam {
     PHASE_NAME: string
-    SOURCE_OF_FUND: string
     CAMPAIGN_ID: string
     ENDBLOCK: string
     REWARD_PER_BLOCK: string
@@ -28,7 +27,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const EXACT_ETA = '1619703660';
   const REWARDINFO: IAddGrazingRangeRewardInfoParamList = [{
     PHASE_NAME: 'PHASE_1',
-    SOURCE_OF_FUND: '',
     CAMPAIGN_ID: '2',
     ENDBLOCK: '8405700',
     REWARD_PER_BLOCK: ethers.utils.parseEther('1000').toString()
@@ -52,11 +50,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log(`>> Timelock: Adding a grazing range's reward info: "${rewardInfo.PHASE_NAME}" via Timelock`);
     await timelock.queueTransaction(
         GRAZING_RANGE, '0',
-        'addRewardInfo(uint256,uint256,uint256,uint256)',
+        'addRewardInfo(uint256,uint256,uint256)',
         ethers.utils.defaultAbiCoder.encode(
-            ['uint256','uint256', 'uint256', 'uint256'],
+            ['uint256', 'uint256', 'uint256'],
             [
-                rewardInfo.SOURCE_OF_FUND,
                 rewardInfo.CAMPAIGN_ID,
                 rewardInfo.ENDBLOCK,
                 rewardInfo.REWARD_PER_BLOCK,
@@ -64,7 +61,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         ), EXACT_ETA
     );
     console.log("generate timelock.executeTransaction:")
-    console.log(`await timelock.executeTransaction('${GRAZING_RANGE}', '0', 'addRewardInfo(uint256,uint256,uint256,uint256)', ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256', 'uint256', 'uint256'],['${rewardInfo.SOURCE_OF_FUND}','${rewardInfo.CAMPAIGN_ID}','${rewardInfo.ENDBLOCK}','${rewardInfo.REWARD_PER_BLOCK}']), ${EXACT_ETA})`)
+    console.log(`await timelock.executeTransaction('${GRAZING_RANGE}', '0', 'addRewardInfo(uint256,uint256,uint256)', ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256', 'uint256'],['${rewardInfo.CAMPAIGN_ID}','${rewardInfo.ENDBLOCK}','${rewardInfo.REWARD_PER_BLOCK}']), ${EXACT_ETA})`)
     console.log("✅ Done");
   }
 };

--- a/test/GrazingRange.test.ts
+++ b/test/GrazingRange.test.ts
@@ -288,28 +288,7 @@ describe('GrazingRange', () => {
       })
     })
     context('When some parameters are invalid', async () => {
-      context("When the caller isn't the reward holder", async () => {
-        context('When rewardHolder has been set to the new account', async() => {
-          it('previous holder should not be able to add reward info', async() => {
-            await rewardTokenAsDeployer.mint(await deployer.getAddress(), constants.MaxUint256)
-            await grazingRangeAsDeployer.addCampaignInfo(
-              stakingToken.address, 
-              rewardToken.address, 
-              mockedBlock.add(8).toString(),
-            )
-            grazingRangeAsDeployer.addRewardInfo(
-              0, 
-              mockedBlock.add(11).toString(),
-              INITIAL_BONUS_REWARD_PER_BLOCK,
-            )
-            await grazingRangeAsDeployer.setRewardHolder(await alice.getAddress())
-            await expect(grazingRangeAsDeployer.addRewardInfo(
-              0, 
-              mockedBlock.add(13).toString(),
-              INITIAL_BONUS_REWARD_PER_BLOCK,
-            )).to.revertedWith("GrazingRange::onlyRewardHolder::caller is not a reward holder")
-          })
-        })
+      context("When the caller isn't the owner", async () => {
         it('should reverted since there is a modifier only owner validating the ownership', async () => {
           const mintedReward = INITIAL_BONUS_REWARD_PER_BLOCK.mul(mockedBlock.add(11).sub(mockedBlock.add(8)))
           await rewardTokenAsDeployer.mint(await deployer.getAddress(), mintedReward)


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
This is a refactor PR for removing a source of fund parameter and change to reward holder, only a single reward holder is allowed in the contract

## Why?
because when the source of fund is a parameter for add reward info, if the owner is a malicious one, they might be able to use any account having approved a grazing range contract to bring a reward token to the contract. Changing to initialize parameter can fix this properly.

