### PR TITLE
[FIX] Improve Precision by multiplication and division reordering

### DIFF
--- a/contracts/6/protocol/Vault.sol
+++ b/contracts/6/protocol/Vault.sol
@@ -281,7 +281,10 @@ contract Vault is IVault, ERC20UpgradeSafe, ReentrancyGuardUpgradeSafe, OwnableU
       _addDebt(id, debt);
       _fairLaunchDeposit(id, pos.debtShare);
     }
-    // 5. Return excess token back.
+    // 5. Release execution scope
+    POSITION_ID = _NO_ID;
+    STRATEGY = _NO_ADDRESS;
+    // 6. Return excess token back.
     if (back > lessDebt) {
       if(token == config.getWrappedNativeAddr()) {
         SafeToken.safeTransfer(token, config.getWNativeRelayer(), back.sub(lessDebt));
@@ -291,9 +294,6 @@ contract Vault is IVault, ERC20UpgradeSafe, ReentrancyGuardUpgradeSafe, OwnableU
         SafeToken.safeTransfer(token, msg.sender, back.sub(lessDebt));
       }
     }
-    // 6. Release execution scope
-    POSITION_ID = _NO_ID;
-    STRATEGY = _NO_ADDRESS;
   }
 
   /// @dev Kill the given to the position. Liquidate it immediately if killFactor condition is met.

--- a/contracts/6/protocol/workers/CakeMaxiWorkerConfig.sol
+++ b/contracts/6/protocol/workers/CakeMaxiWorkerConfig.sol
@@ -95,8 +95,8 @@ contract CakeMaxiWorkerConfig is OwnableUpgradeSafe, IWorkerConfig {
         (uint256 price, uint256 lastUpdate) = oracle.getPrice(token0, token1);
         require(lastUpdate >= now - 1 days, "CakeMaxiWorkerConfig::isStable:: price too stale");
         uint256 spotPrice = r1.mul(1e18).div(r0);
-        require(spotPrice <= price.mul(maxPriceDiff).div(10000), "CakeMaxiWorkerConfig::isStable:: price too high");
-        require(spotPrice >= price.mul(10000).div(maxPriceDiff), "CakeMaxiWorkerConfig::isStable:: price too low");
+        require(spotPrice.mul(10000) <= price.mul(maxPriceDiff), "CakeMaxiWorkerConfig::isStable:: price too high");
+        require(spotPrice.mul(maxPriceDiff) >= price.mul(10000), "CakeMaxiWorkerConfig::isStable:: price too low");
     }
     return true;
   }


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
This is a fixing PR based on the audit's suggestion
- move division part to the other side, thus making it a multiplication rather than division (try to avoid division)

## Why?
try to avoid division to mitigate possible precision loss