### PR TITLE
[main][chore] Rename event in Single Asset Partial Close Liquidate

### DIFF
--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted-single-asset/PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted-single-asset/PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate.sol
@@ -40,7 +40,7 @@ contract PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate is
   address public wNative;
   mapping(address => bool) public okWorkers;
 
-  event PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate(
+  event PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidateEvent(
     address indexed baseToken,
     address indexed farmToken,
     uint256 amounToLiquidate
@@ -97,7 +97,7 @@ contract PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate is
     // 5. Reset approval for safety reason
     farmingToken.safeApprove(address(router), 0);
 
-    emit PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate(
+    emit PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidateEvent(
       baseToken,
       farmingToken,
       farmingTokenToLiquidate

--- a/test/PancakeswapV2_Restricted_SingleAsset_StrategyPartialCloseLiquidate.test.ts
+++ b/test/PancakeswapV2_Restricted_SingleAsset_StrategyPartialCloseLiquidate.test.ts
@@ -290,7 +290,7 @@ describe('PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate', () =
             [farmingTokenToLiquidate, '0']
           )],
         )
-      )).to.emit(strat, 'PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate').withArgs(
+      )).to.emit(strat, 'PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidateEvent').withArgs(
         wbnb.address, farmingToken.address , farmingTokenToLiquidate
       );
       const aliceBalanceAfter = await wbnb.balanceOf(await alice.getAddress())
@@ -394,7 +394,7 @@ describe('PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate', () =
             [farmingTokenToLiquidate, '0']
           )],
         )
-      )).to.emit(strat, 'PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate').withArgs(
+      )).to.emit(strat, 'PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidateEvent').withArgs(
         baseToken.address, farmingToken.address, farmingTokenToLiquidate
       );
 


### PR DESCRIPTION
## Description
Rename event in Single Asset Partial Close Liquidate.

## Why?
Match with other strategies convention.
