### PR TITLE
[main][feat] Update reinvest threshold logic

### DIFF
--- a/contracts/6/protocol/workers/pcs/PancakeswapV2Worker02.sol
+++ b/contracts/6/protocol/workers/pcs/PancakeswapV2Worker02.sol
@@ -230,6 +230,7 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
     // 3. Withdraw all the rewards.
     masterChef.withdraw(pid, 0);
     uint256 reward = cake.balanceOf(address(this));
+    if (reward == 0) return;
 
     // 4. Send the reward bounty to the _treasuryAccount.
     uint256 bounty = reward.mul(_treasuryBountyBps) / 10000;

--- a/contracts/6/protocol/workers/pcs/PancakeswapV2Worker02.sol
+++ b/contracts/6/protocol/workers/pcs/PancakeswapV2Worker02.sol
@@ -202,23 +202,26 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
 
   /// @dev Re-invest whatever this worker has earned back to staked LP tokens.
   function reinvest() external override onlyEOA onlyReinvestor nonReentrant {
-    _reinvest(msg.sender, reinvestBountyBps, 0);
+    _reinvest(msg.sender, reinvestBountyBps, 0, 0);
     // in case of beneficial vault equals to operator vault, call buyback to transfer some buyback amount back to the vault
     // This can't be called within the _reinvest statement since _reinvest is called within the `work` as well
     _buyback();
   }
 
-  /// @notice internal method for reinvest.
-  /// @param _treasuryAccount - The account to receive reinvest fees
-  /// @param _treasuryBountyBps - The fees in BPS that will be charged for reinvest
+  /// @dev internal method for reinvest.
+  /// @param _treasuryAccount - The account to receive reinvest fees.
+  /// @param _treasuryBountyBps - The fees in BPS that will be charged for reinvest.
+  /// @param _callerBalance - The balance that is owned by the msg.sender within the execution scope.
+  /// @param _reinvestThreshold - The threshold to be reinvested if pendingCake pass over.
   function _reinvest(
     address _treasuryAccount,
     uint256 _treasuryBountyBps,
-    uint256 _callerBalance
+    uint256 _callerBalance,
+    uint256 _reinvestThreshold
   ) internal {
     require(_treasuryAccount != address(0), "PancakeswapV2Worker02::_reinvest:: bad treasury account");
-    // 1. Return if pendingCake <= reinvestThreshold
-    if (masterChef.pendingCake(pid, address(this)) <= reinvestThreshold) return;
+    // 1. Return if pendingCake <= _reinvestThreshold
+    if (masterChef.pendingCake(pid, address(this)) <= _reinvestThreshold) return;
 
     // 2. Approve tokens
     cake.safeApprove(address(router), uint256(-1));
@@ -266,7 +269,7 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
   ) external override onlyOperator nonReentrant {
     // 1. If a treasury configs are not ready. Not reinvest.
     if (treasuryAccount != address(0) && treasuryBountyBps != 0)
-      _reinvest(treasuryAccount, treasuryBountyBps, actualBaseTokenBalance());
+      _reinvest(treasuryAccount, treasuryBountyBps, actualBaseTokenBalance(), reinvestThreshold);
     // 2. Convert this position back to LP tokens.
     _removeShare(id);
     // 3. Perform the worker strategy; sending LP tokens + BaseToken; expecting LP tokens + BaseToken.
@@ -332,7 +335,9 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
     emit Liquidate(id, liquidatedAmount);
   }
 
-  /// @notice some portion of a bounty from reinvest will be sent to beneficialVault to increase the size of totalToken
+  /// @dev Some portion of a bounty from reinvest will be sent to beneficialVault to increase the size of totalToken.
+  /// @param _beneficialVaultBounty - The amount of CAKE to be swapped to BTOKEN & send back to the Vault.
+  /// @param _callerBalance - The balance that is owned by the msg.sender within the execution scope.
   function _rewardToBeneficialVault(uint256 _beneficialVaultBounty, uint256 _callerBalance) internal {
     /// 1. read base token from beneficialVault
     address beneficialVaultToken = beneficialVault.token();
@@ -351,7 +356,7 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
     }
   }
 
-  /// @notice for transfering a buyback amount to the particular beneficial vault
+  /// @dev for transfering a buyback amount to the particular beneficial vault
   // this will be triggered when beneficialVaultToken equals to baseToken.
   function _buyback() internal {
     if (buybackAmount == 0) return;
@@ -361,7 +366,7 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
     emit BeneficialVaultTokenBuyback(msg.sender, beneficialVault, _buybackAmount);
   }
 
-  /// @notice since buybackAmount variable has been created to collect a buyback balance when during the reinvest within the work method,
+  /// @dev since buybackAmount variable has been created to collect a buyback balance when during the reinvest within the work method,
   /// thus the actualBaseTokenBalance exists to differentiate an actual base token balance balance without taking buy back amount into account
   function actualBaseTokenBalance() internal view returns (uint256) {
     return baseToken.myBalance().sub(buybackAmount);
@@ -419,7 +424,7 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
     return rewardPath;
   }
 
-  /// @notice Internal function to get reinvest path. Return route through WBNB if reinvestPath not set.
+  /// @dev Internal function to get reinvest path. Return route through WBNB if reinvestPath not set.
   function getReinvestPath() public view returns (address[] memory) {
     if (reinvestPath.length != 0) return reinvestPath;
     address[] memory path;
@@ -436,7 +441,7 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
     return path;
   }
 
-  /// @dev Set the reward bounty for calling reinvest operations.
+  /// @dev Set the reinvest configuration.
   /// @param _reinvestBountyBps - The bounty value to update.
   /// @param _reinvestThreshold - The threshold to update.
   /// @param _reinvestPath - The reinvest path to update.
@@ -522,7 +527,7 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
     emit SetCriticalStrategy(msg.sender, addStrat, liqStrat);
   }
 
-  /// @notice Set treasury configurations.
+  /// @dev Set treasury configurations.
   /// @param _treasuryAccount - The treasury address to update
   /// @param _treasuryBountyBps - The treasury bounty to update
   function setTreasuryConfig(address _treasuryAccount, uint256 _treasuryBountyBps) external onlyOwner {
@@ -537,7 +542,7 @@ contract PancakeswapV2Worker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe
     emit SetTreasuryConfig(msg.sender, treasuryAccount, treasuryBountyBps);
   }
 
-  /// @notice Set beneficial vault related data including beneficialVaultBountyBps, beneficialVaultAddress, and rewardPath
+  /// @dev Set beneficial vault related data including beneficialVaultBountyBps, beneficialVaultAddress, and rewardPath
   /// @param _beneficialVaultBountyBps - The bounty value to update.
   /// @param _beneficialVault - beneficialVaultAddress
   /// @param _rewardPath - reward token path from rewardToken to beneficialVaultToken

--- a/contracts/6/protocol/workers/single-asset/CakeMaxiWorker02.sol
+++ b/contracts/6/protocol/workers/single-asset/CakeMaxiWorker02.sol
@@ -229,6 +229,7 @@ contract CakeMaxiWorker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IWo
     // 4. withdraw all the rewards.
     masterChef.leaveStaking(0);
     uint256 reward = farmingToken.myBalance();
+    if (reward == 0) return;
 
     // 5. send the reward bounty to the caller.
     uint256 bounty = reward.mul(_treasuryBountyBps) / 10000;

--- a/contracts/6/protocol/workers/single-asset/CakeMaxiWorker02.sol
+++ b/contracts/6/protocol/workers/single-asset/CakeMaxiWorker02.sol
@@ -217,21 +217,16 @@ contract CakeMaxiWorker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IWo
     uint256 _reinvestThreshold
   ) internal {
     require(_treasuryAccount != address(0), "CakeMaxiWorker02::_reinvest:: bad treasury account");
-
-    // 1. approve tokens
-    farmingToken.safeApprove(address(masterChef), uint256(-1));
-
-    // 2. reset all reward balance since all rewards will be reinvested
+    // 1. reset all reward balance since all rewards will be reinvested
     rewardBalance = 0;
 
-    // 3. withdraw all the rewards.
+    // 2. withdraw all the rewards. Return if rewards smaller than the threshold.
     masterChef.leaveStaking(0);
     uint256 reward = farmingToken.myBalance();
-    if (reward <= _reinvestThreshold) {
-      // reset approvals and return.
-      farmingToken.safeApprove(address(masterChef), 0);
-      return;
-    }
+    if (reward <= _reinvestThreshold) return;
+
+    // 3. approve tokens
+    farmingToken.safeApprove(address(masterChef), uint256(-1));
 
     // 4. send the reward bounty to the caller.
     uint256 bounty = reward.mul(_treasuryBountyBps) / 10000;

--- a/contracts/6/protocol/workers/waultswap/WaultSwapWorker02.sol
+++ b/contracts/6/protocol/workers/waultswap/WaultSwapWorker02.sol
@@ -228,6 +228,7 @@ contract WaultSwapWorker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
     // 3. Withdraw all the rewards.
     wexMaster.withdraw(pid, 0, true);
     uint256 reward = wex.balanceOf(address(this));
+    if (reward == 0) return;
 
     // 4. Send the reward bounty to the _treasuryAccount.
     uint256 bounty = reward.mul(_treasuryBountyBps) / 10000;

--- a/contracts/6/protocol/workers/waultswap/WaultSwapWorker02.sol
+++ b/contracts/6/protocol/workers/waultswap/WaultSwapWorker02.sol
@@ -218,20 +218,14 @@ contract WaultSwapWorker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
     uint256 _reinvestThreshold
   ) internal {
     require(_treasuryAccount != address(0), "WaultSwapWorker02::_reinvest:: bad treasury account");
-
-    // 1. Approve tokens
-    wex.safeApprove(address(router), uint256(-1));
-    address(lpToken).safeApprove(address(wexMaster), uint256(-1));
-
-    // 2. Withdraw all the rewards. Return if reward <= _reinvestThershold.
+    // 1. Withdraw all the rewards. Return if reward <= _reinvestThershold.
     wexMaster.withdraw(pid, 0, true);
     uint256 reward = wex.balanceOf(address(this));
-    if (reward <= _reinvestThreshold) {
-      // reset approvals and return.
-      wex.safeApprove(address(router), 0);
-      address(lpToken).safeApprove(address(wexMaster), 0);
-      return;
-    }
+    if (reward <= _reinvestThreshold) return;
+
+    // 2. Approve tokens
+    wex.safeApprove(address(router), uint256(-1));
+    address(lpToken).safeApprove(address(wexMaster), uint256(-1));
 
     // 3. Send the reward bounty to the _treasuryAccount.
     uint256 bounty = reward.mul(_treasuryBountyBps) / 10000;

--- a/test/CakeMaxiWorker02.test.ts
+++ b/test/CakeMaxiWorker02.test.ts
@@ -515,6 +515,19 @@ describe('CakeMaxiWorker02', () => {
     })
   })
 
+  describe("#setMaxReinvestBountyBps", async() => {
+    it('should successfully set a max reinvest bounty bps', async() => {
+      await cakeMaxiWorkerNative.setMaxReinvestBountyBps('3000')
+      expect(await cakeMaxiWorkerNative.maxReinvestBountyBps()).to.be.eq('3000')
+    })
+
+    it('should revert when new max reinvest bounty over 30%', async() => {
+      await expect(cakeMaxiWorkerNative.setMaxReinvestBountyBps('3001'))
+        .to.be.revertedWith('CakeMaxiWorker02::setMaxReinvestBountyBps:: _maxReinvestBountyBps exceeded 30%')
+      expect(await cakeMaxiWorkerNative.maxReinvestBountyBps()).to.be.eq('2000')
+    })
+  })
+
   describe("#work()", async () => {
     context("When the caller is not an operator", async() => {
       it('should be reverted', async () => {

--- a/test/Vault_PancakeswapV202.test.ts
+++ b/test/Vault_PancakeswapV202.test.ts
@@ -446,29 +446,57 @@ describe('Vault - PancakeswapV202', () => {
   });
 
   context('when owner is setting worker', async() => {
-    it('should set reinvest config correctly', async() => {
-      await expect(pancakeswapV2Worker.setReinvestConfig(
-        250, ethers.utils.parseEther('1'), [cake.address, baseToken.address]
-      )).to.be.emit(pancakeswapV2Worker, 'SetReinvestConfig')
-        .withArgs(await deployer.getAddress(), 250, ethers.utils.parseEther('1'), [cake.address, baseToken.address])
-      expect(await pancakeswapV2Worker.reinvestBountyBps()).to.be.bignumber.eq(250);
-      expect(await pancakeswapV2Worker.reinvestThreshold()).to.be.bignumber.eq(ethers.utils.parseEther('1'))
-      expect(await pancakeswapV2Worker.getReinvestPath()).to.deep.eq([cake.address, baseToken.address])
-    });
+    describe("#reinvestConfig", async() => {
+      it('should set reinvest config correctly', async() => {
+        await expect(pancakeswapV2Worker.setReinvestConfig(
+          250, ethers.utils.parseEther('1'), [cake.address, baseToken.address]
+        )).to.be.emit(pancakeswapV2Worker, 'SetReinvestConfig')
+          .withArgs(await deployer.getAddress(), 250, ethers.utils.parseEther('1'), [cake.address, baseToken.address])
+        expect(await pancakeswapV2Worker.reinvestBountyBps()).to.be.bignumber.eq(250);
+        expect(await pancakeswapV2Worker.reinvestThreshold()).to.be.bignumber.eq(ethers.utils.parseEther('1'))
+        expect(await pancakeswapV2Worker.getReinvestPath()).to.deep.eq([cake.address, baseToken.address])
+      });
 
-    it('should set max reinvest bounty', async() => {
-      await pancakeswapV2Worker.setMaxReinvestBountyBps(200)
-      expect(await pancakeswapV2Worker.maxReinvestBountyBps()).to.be.eq(200)
-    });
+      it('should revert when owner set reinvestBountyBps > max', async() => {
+        await expect(
+          pancakeswapV2Worker.setReinvestConfig(1000, '0', [cake.address, baseToken.address])
+        ).to.be.revertedWith('PancakeswapV2Worker02::setReinvestConfig:: _reinvestBountyBps exceeded maxReinvestBountyBps');
+        expect(await pancakeswapV2Worker.reinvestBountyBps()).to.be.bignumber.eq(100);
+      });
 
-    it('should successfully set a treasury account', async() => {
-      const aliceAddr = await alice.getAddress()
-      await pancakeswapV2Worker.setTreasuryConfig(aliceAddr, REINVEST_BOUNTY_BPS);
-      expect(await pancakeswapV2Worker.treasuryAccount()).to.eq(aliceAddr)
+      it('should revert when owner set reinvest path that doesn\'t start with $CAKE and end with $BTOKN', async() => {
+        await expect(
+          pancakeswapV2Worker.setReinvestConfig(200, '0', [baseToken.address, cake.address])
+        ).to.be.revertedWith('PancakeswapV2Worker02::setReinvestConfig:: _reinvestPath must start with CAKE, end with BTOKEN')
+      });
     })
 
-    context('when treasury bounty > max reinvest bounty', async () => {
-      it('should revert', async() => {
+    describe("#setMaxReinvestBountyBps", async() => {
+      it('should set max reinvest bounty', async() => {
+        await pancakeswapV2Worker.setMaxReinvestBountyBps(200)
+        expect(await pancakeswapV2Worker.maxReinvestBountyBps()).to.be.eq(200)
+      });
+
+      it('should revert when new max reinvest bounty over 30%', async() => {
+        await expect(pancakeswapV2Worker.setMaxReinvestBountyBps('3001'))
+          .to.be.revertedWith('PancakeswapV2Worker02::setMaxReinvestBountyBps:: _maxReinvestBountyBps exceeded 30%')
+        expect(await pancakeswapV2Worker.maxReinvestBountyBps()).to.be.eq('500')
+      })
+    })
+
+    describe('#setTreasuryConfig', async() => {
+      it('should successfully set a treasury account', async() => {
+        const aliceAddr = await alice.getAddress()
+        await pancakeswapV2Worker.setTreasuryConfig(aliceAddr, REINVEST_BOUNTY_BPS);
+        expect(await pancakeswapV2Worker.treasuryAccount()).to.eq(aliceAddr)
+      })
+
+      it('should successfully set a treasury bounty', async() => {
+        await pancakeswapV2Worker.setTreasuryConfig(DEPLOYER, 499);
+        expect(await pancakeswapV2Worker.treasuryBountyBps()).to.eq(499)
+      })
+
+      it('should revert when a new treasury bounty > max reinvest bounty bps', async() => {
         await expect(
           pancakeswapV2Worker.setTreasuryConfig(DEPLOYER, parseInt(MAX_REINVEST_BOUNTY) + 1)
         ).to.revertedWith('PancakeswapV2Worker02::setTreasuryConfig:: _treasuryBountyBps exceeded maxReinvestBountyBps');
@@ -476,31 +504,12 @@ describe('Vault - PancakeswapV202', () => {
       })
     })
 
-    context('when treasury bounty <= max reinvest bounty', async () => {
-      it('should successfully set a treasury bounty', async() => {
-        await pancakeswapV2Worker.setTreasuryConfig(DEPLOYER, 499);
-        expect(await pancakeswapV2Worker.treasuryBountyBps()).to.eq(499)
+    describe('#setStrategyOk', async() => {
+      it('should set strat ok', async() => {
+        await pancakeswapV2Worker.setStrategyOk([await alice.getAddress()], true);
+        expect(await pancakeswapV2Worker.okStrats(await alice.getAddress())).to.be.eq(true);
       })
     })
-
-    
-    it('should revert when owner set reinvestBountyBps > max', async() => {
-      await expect(
-        pancakeswapV2Worker.setReinvestConfig(1000, '0', [cake.address, baseToken.address])
-      ).to.be.revertedWith('PancakeswapV2Worker02::setReinvestConfig:: _reinvestBountyBps exceeded maxReinvestBountyBps');
-      expect(await pancakeswapV2Worker.reinvestBountyBps()).to.be.bignumber.eq(100);
-    });
-
-    it('should revert when owner set reinvest path that doesn\'t start with $CAKE and end with $BTOKN', async() => {
-      await expect(
-        pancakeswapV2Worker.setReinvestConfig(200, '0', [baseToken.address, cake.address])
-      ).to.be.revertedWith('PancakeswapV2Worker02::setReinvestConfig:: reinvestPath must start with CAKE, end with BTOKEN')
-    })
-
-    it('should set strat ok', async() => {
-      await pancakeswapV2Worker.setStrategyOk([await alice.getAddress()], true);
-      expect(await pancakeswapV2Worker.okStrats(await alice.getAddress())).to.be.eq(true);
-    });
   });
 
   context('when user uses LYF', async() => {
@@ -567,1759 +576,1759 @@ describe('Vault - PancakeswapV202', () => {
     })
     
     context('when user is EOA', async() => {
-      // it('should allow to open a position without debt', async () => {
-      //   // Deployer deposits 3 BTOKEN to the bank
-      //   await baseToken.approve(vault.address, ethers.utils.parseEther('3'));
-      //   await vault.deposit(ethers.utils.parseEther('3'));
+      it('should allow to open a position without debt', async () => {
+        // Deployer deposits 3 BTOKEN to the bank
+        await baseToken.approve(vault.address, ethers.utils.parseEther('3'));
+        await vault.deposit(ethers.utils.parseEther('3'));
     
-      //   // Alice can take 0 debt ok
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('0.3'));
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('0.3'),
-      //     ethers.utils.parseEther('0'),
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
-      // });
+        // Alice can take 0 debt ok
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('0.3'));
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('0.3'),
+          ethers.utils.parseEther('0'),
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
+      });
   
-      // it('should not allow to open a position with debt less than MIN_DEBT_SIZE', async () => {
-      //   // Deployer deposits 3 BTOKEN to the bank
-      //   await baseToken.approve(vault.address, ethers.utils.parseEther('3'));
-      //   await vault.deposit(ethers.utils.parseEther('3'));
+      it('should not allow to open a position with debt less than MIN_DEBT_SIZE', async () => {
+        // Deployer deposits 3 BTOKEN to the bank
+        await baseToken.approve(vault.address, ethers.utils.parseEther('3'));
+        await vault.deposit(ethers.utils.parseEther('3'));
   
-      //   // Alice cannot take 0.3 debt because it is too small
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('0.3'));
-      //   await expect(
-      //     vaultAsAlice.work(
-      //       0,
-      //       pancakeswapV2Worker.address,
-      //       ethers.utils.parseEther('0.3'),
-      //       ethers.utils.parseEther('0.3'),
-      //       '0',
-      //       ethers.utils.defaultAbiCoder.encode(
-      //         ['address', 'bytes'],
-      //         [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //           ['uint256'],
-      //           ['0'])
-      //         ]
-      //       )
-      //     )
-      //   ).to.be.revertedWith('too small debt size');
-      // });
+        // Alice cannot take 0.3 debt because it is too small
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('0.3'));
+        await expect(
+          vaultAsAlice.work(
+            0,
+            pancakeswapV2Worker.address,
+            ethers.utils.parseEther('0.3'),
+            ethers.utils.parseEther('0.3'),
+            '0',
+            ethers.utils.defaultAbiCoder.encode(
+              ['address', 'bytes'],
+              [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+                ['uint256'],
+                ['0'])
+              ]
+            )
+          )
+        ).to.be.revertedWith('too small debt size');
+      });
   
-      // it('should not allow to open the position with bad work factor', async () => {
-      //   // Deployer deposits 3 BTOKEN to the bank
-      //   await baseToken.approve(vault.address, ethers.utils.parseEther('3'));
-      //   await vault.deposit(ethers.utils.parseEther('3'));
+      it('should not allow to open the position with bad work factor', async () => {
+        // Deployer deposits 3 BTOKEN to the bank
+        await baseToken.approve(vault.address, ethers.utils.parseEther('3'));
+        await vault.deposit(ethers.utils.parseEther('3'));
     
-      //   // Alice cannot take 1 BTOKEN loan because she only put 0.3 BTOKEN as a collateral
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('0.3'));
-      //   await expect(
-      //     vaultAsAlice.work(
-      //       0,
-      //       pancakeswapV2Worker.address,
-      //       ethers.utils.parseEther('0.3'),
-      //       ethers.utils.parseEther('1'),
-      //       '0',
-      //       ethers.utils.defaultAbiCoder.encode(
-      //         ['address', 'bytes'],
-      //         [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //           ['uint256'],
-      //           ['0'])
-      //         ]
-      //       )
-      //     )
-      //   ).to.be.revertedWith('bad work factor');
-      // });
+        // Alice cannot take 1 BTOKEN loan because she only put 0.3 BTOKEN as a collateral
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('0.3'));
+        await expect(
+          vaultAsAlice.work(
+            0,
+            pancakeswapV2Worker.address,
+            ethers.utils.parseEther('0.3'),
+            ethers.utils.parseEther('1'),
+            '0',
+            ethers.utils.defaultAbiCoder.encode(
+              ['address', 'bytes'],
+              [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+                ['uint256'],
+                ['0'])
+              ]
+            )
+          )
+        ).to.be.revertedWith('bad work factor');
+      });
   
-      // it('should not allow positions if Vault has less BaseToken than requested loan', async () => {
-      //   // Alice cannot take 1 BTOKEN loan because the contract does not have it
-      //   baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
-      //   await expect(
-      //     vaultAsAlice.work(
-      //       0,
-      //       pancakeswapV2Worker.address,
-      //       ethers.utils.parseEther('1'),
-      //       ethers.utils.parseEther('1'),
-      //       '0',
-      //       ethers.utils.defaultAbiCoder.encode(
-      //         ['address', 'bytes'],
-      //         [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //           ['uint256'],
-      //           ['0'])
-      //         ]
-      //       )
-      //     )
-      //   ).to.be.revertedWith('insufficient funds in the vault');
-      // });
+      it('should not allow positions if Vault has less BaseToken than requested loan', async () => {
+        // Alice cannot take 1 BTOKEN loan because the contract does not have it
+        baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
+        await expect(
+          vaultAsAlice.work(
+            0,
+            pancakeswapV2Worker.address,
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            '0',
+            ethers.utils.defaultAbiCoder.encode(
+              ['address', 'bytes'],
+              [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+                ['uint256'],
+                ['0'])
+              ]
+            )
+          )
+        ).to.be.revertedWith('insufficient funds in the vault');
+      });
   
-      // it('should not able to liquidate healthy position', async () => {
-      //   // Deployer deposits 3 BTOKEN to the bank
-      //   const deposit = ethers.utils.parseEther('3');
-      //   await baseToken.approve(vault.address, deposit);
-      //   await vault.deposit(deposit);
+      it('should not able to liquidate healthy position', async () => {
+        // Deployer deposits 3 BTOKEN to the bank
+        const deposit = ethers.utils.parseEther('3');
+        await baseToken.approve(vault.address, deposit);
+        await vault.deposit(deposit);
     
-      //   // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
-      //   const loan = ethers.utils.parseEther('1');
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'))
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     loan,
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
+        const loan = ethers.utils.parseEther('1');
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'))
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          loan,
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
     
-      //   // Her position should have ~2 BTOKEN health (minus some small trading fee)
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')))
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   await vault.deposit(0); // Random action to trigger interest computation
+        // Her position should have ~2 BTOKEN health (minus some small trading fee)
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')))
+        await pancakeswapV2WorkerAsEve.reinvest();
+        await vault.deposit(0); // Random action to trigger interest computation
     
-      //   // You can't liquidate her position yet
-      //   await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
-      // });
+        // You can't liquidate her position yet
+        await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
+      });
   
-      // it('should work', async () => {
-      //   // Deployer deposits 3 BTOKEN to the bank
-      //   const deposit = ethers.utils.parseEther('3');
-      //   await baseToken.approve(vault.address, deposit);
-      //   await vault.deposit(deposit);
+      it('should work', async () => {
+        // Deployer deposits 3 BTOKEN to the bank
+        const deposit = ethers.utils.parseEther('3');
+        await baseToken.approve(vault.address, deposit);
+        await vault.deposit(deposit);
     
-      //   // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
-      //   const loan = ethers.utils.parseEther('1');
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'))
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     loan,
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
+        const loan = ethers.utils.parseEther('1');
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'))
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          loan,
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   // Her position should have ~2 NATIVE health (minus some small trading fee)
-      //   expect(await pancakeswapV2Worker.health(1)).to.be.bignumber.eq(ethers.utils.parseEther('1.997883397660681282'));
+        // Her position should have ~2 NATIVE health (minus some small trading fee)
+        expect(await pancakeswapV2Worker.health(1)).to.be.bignumber.eq(ethers.utils.parseEther('1.997883397660681282'));
     
-      //   // Eve comes and trigger reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   AssertHelpers.assertAlmostEqual(
-      //     (CAKE_REWARD_PER_BLOCK.mul('2').mul(REINVEST_BOUNTY_BPS).div('10000')).toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        // Eve comes and trigger reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await pancakeswapV2WorkerAsEve.reinvest();
+        AssertHelpers.assertAlmostEqual(
+          (CAKE_REWARD_PER_BLOCK.mul('2').mul(REINVEST_BOUNTY_BPS).div('10000')).toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
     
-      //   await vault.deposit(0); // Random action to trigger interest computation
-      //   const healthDebt = await vault.positionInfo('1');
-      //   expect(healthDebt[0]).to.be.bignumber.above(ethers.utils.parseEther('2'));
-      //   const interest = ethers.utils.parseEther('0.3'); // 30% interest rate
-      //   AssertHelpers.assertAlmostEqual(
-      //     healthDebt[1].toString(),
-      //     interest.add(loan).toString(),
-      //   );
-      //   AssertHelpers.assertAlmostEqual(
-      //     (await baseToken.balanceOf(vault.address)).toString(),
-      //     deposit.sub(loan).toString(),
-      //   );
-      //   AssertHelpers.assertAlmostEqual(
-      //     (await vault.vaultDebtVal()).toString(),
-      //     interest.add(loan).toString(),
-      //   );
+        await vault.deposit(0); // Random action to trigger interest computation
+        const healthDebt = await vault.positionInfo('1');
+        expect(healthDebt[0]).to.be.bignumber.above(ethers.utils.parseEther('2'));
+        const interest = ethers.utils.parseEther('0.3'); // 30% interest rate
+        AssertHelpers.assertAlmostEqual(
+          healthDebt[1].toString(),
+          interest.add(loan).toString(),
+        );
+        AssertHelpers.assertAlmostEqual(
+          (await baseToken.balanceOf(vault.address)).toString(),
+          deposit.sub(loan).toString(),
+        );
+        AssertHelpers.assertAlmostEqual(
+          (await vault.vaultDebtVal()).toString(),
+          interest.add(loan).toString(),
+        );
     
-      //   const reservePool = interest.mul(RESERVE_POOL_BPS).div('10000');
-      //   AssertHelpers.assertAlmostEqual(
-      //     reservePool.toString(),
-      //     (await vault.reservePool()).toString(),
-      //   );
-      //   AssertHelpers.assertAlmostEqual(
-      //     deposit.add(interest).sub(reservePool).toString(),
-      //     (await vault.totalToken()).toString(),
-      //   );
-      // });
+        const reservePool = interest.mul(RESERVE_POOL_BPS).div('10000');
+        AssertHelpers.assertAlmostEqual(
+          reservePool.toString(),
+          (await vault.reservePool()).toString(),
+        );
+        AssertHelpers.assertAlmostEqual(
+          deposit.add(interest).sub(reservePool).toString(),
+          (await vault.totalToken()).toString(),
+        );
+      });
   
-      // it('should has correct interest rate growth', async () => {
-      //   // Deployer deposits 3 BTOKEN to the bank
-      //   const deposit = ethers.utils.parseEther('3');
-      //   await baseToken.approve(vault.address, deposit);
-      //   await vault.deposit(deposit);
+      it('should has correct interest rate growth', async () => {
+        // Deployer deposits 3 BTOKEN to the bank
+        const deposit = ethers.utils.parseEther('3');
+        await baseToken.approve(vault.address, deposit);
+        await vault.deposit(deposit);
   
-      //   // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
-      //   const loan = ethers.utils.parseEther('1');
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     loan,
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
+        const loan = ethers.utils.parseEther('1');
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          loan,
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
   
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   await vault.deposit(0); // Random action to trigger interest computation
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await pancakeswapV2WorkerAsEve.reinvest();
+        await vault.deposit(0); // Random action to trigger interest computation
   
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
   
-      //   await vault.deposit(0); // Random action to trigger interest computation
-      //   const interest = ethers.utils.parseEther('0.3'); //30% interest rate
-      //   const reservePool = interest.mul(RESERVE_POOL_BPS).div('10000');
-      //   AssertHelpers.assertAlmostEqual(
-      //     (deposit
-      //       .add(interest.sub(reservePool))
-      //       .add(interest.sub(reservePool).mul(13).div(10))
-      //       .add(interest.sub(reservePool).mul(13).div(10))).toString(),
-      //     (await vault.totalToken()).toString(),
-      //   );
-      // });
+        await vault.deposit(0); // Random action to trigger interest computation
+        const interest = ethers.utils.parseEther('0.3'); //30% interest rate
+        const reservePool = interest.mul(RESERVE_POOL_BPS).div('10000');
+        AssertHelpers.assertAlmostEqual(
+          (deposit
+            .add(interest.sub(reservePool))
+            .add(interest.sub(reservePool).mul(13).div(10))
+            .add(interest.sub(reservePool).mul(13).div(10))).toString(),
+          (await vault.totalToken()).toString(),
+        );
+      });
   
-      // it('should be able to liquidate bad position', async () => {
-      //   // Deployer deposits 3 BTOKEN to the bank
-      //   const deposit = ethers.utils.parseEther('3');
-      //   await baseToken.approve(vault.address, deposit);
-      //   await vault.deposit(deposit);
+      it('should be able to liquidate bad position', async () => {
+        // Deployer deposits 3 BTOKEN to the bank
+        const deposit = ethers.utils.parseEther('3');
+        await baseToken.approve(vault.address, deposit);
+        await vault.deposit(deposit);
     
-      //   // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
-      //   const loan = ethers.utils.parseEther('1');
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     loan,
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
+        const loan = ethers.utils.parseEther('1');
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          loan,
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
     
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   await vault.deposit(0); // Random action to trigger interest computation
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await pancakeswapV2WorkerAsEve.reinvest();
+        await vault.deposit(0); // Random action to trigger interest computation
     
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
     
-      //   await vault.deposit(0); // Random action to trigger interest computation
-      //   const interest = ethers.utils.parseEther('0.3'); //30% interest rate
-      //   const reservePool = interest.mul(RESERVE_POOL_BPS).div('10000');
-      //   AssertHelpers.assertAlmostEqual(
-      //     (deposit
-      //       .add(interest.sub(reservePool))
-      //       .add(interest.sub(reservePool).mul(13).div(10))
-      //       .add(interest.sub(reservePool).mul(13).div(10))).toString(),
-      //     (await vault.totalToken()).toString()
-      //   );
+        await vault.deposit(0); // Random action to trigger interest computation
+        const interest = ethers.utils.parseEther('0.3'); //30% interest rate
+        const reservePool = interest.mul(RESERVE_POOL_BPS).div('10000');
+        AssertHelpers.assertAlmostEqual(
+          (deposit
+            .add(interest.sub(reservePool))
+            .add(interest.sub(reservePool).mul(13).div(10))
+            .add(interest.sub(reservePool).mul(13).div(10))).toString(),
+          (await vault.totalToken()).toString()
+        );
     
-      //   const eveBefore = await baseToken.balanceOf(await eve.getAddress());
-      //   const aliceAlpacaBefore = await alpacaToken.balanceOf(await alice.getAddress());
+        const eveBefore = await baseToken.balanceOf(await eve.getAddress());
+        const aliceAlpacaBefore = await alpacaToken.balanceOf(await alice.getAddress());
         
-      //   // Now you can liquidate because of the insane interest rate
-      //   await expect(vaultAsEve.kill('1'))
-      //     .to.emit(vaultAsEve, 'Kill')  
+        // Now you can liquidate because of the insane interest rate
+        await expect(vaultAsEve.kill('1'))
+          .to.emit(vaultAsEve, 'Kill')  
   
-      //   expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
-      //   AssertHelpers.assertAlmostEqual(
-      //     deposit
-      //       .add(interest)
-      //       .add(interest.mul(13).div(10))
-      //       .add(interest.mul(13).div(10)).toString(),
-      //     (await baseToken.balanceOf(vault.address)).toString(),
-      //   );
-      //   expect(await vault.vaultDebtVal()).to.be.bignumber.eq(ethers.utils.parseEther('0'));
-      //   AssertHelpers.assertAlmostEqual(
-      //     reservePool.add(reservePool.mul(13).div(10)).add(reservePool.mul(13).div(10)).toString(),
-      //     (await vault.reservePool()).toString(),
-      //   );
-      //   AssertHelpers.assertAlmostEqual(
-      //     deposit
-      //       .add(interest.sub(reservePool))
-      //       .add(interest.sub(reservePool).mul(13).div(10))
-      //       .add(interest.sub(reservePool).mul(13).div(10)).toString(),
-      //     (await vault.totalToken()).toString(),
-      //   );
-      //   expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
-      //   expect(await alpacaToken.balanceOf(await alice.getAddress())).to.be.bignumber.gt(aliceAlpacaBefore);
+        expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
+        AssertHelpers.assertAlmostEqual(
+          deposit
+            .add(interest)
+            .add(interest.mul(13).div(10))
+            .add(interest.mul(13).div(10)).toString(),
+          (await baseToken.balanceOf(vault.address)).toString(),
+        );
+        expect(await vault.vaultDebtVal()).to.be.bignumber.eq(ethers.utils.parseEther('0'));
+        AssertHelpers.assertAlmostEqual(
+          reservePool.add(reservePool.mul(13).div(10)).add(reservePool.mul(13).div(10)).toString(),
+          (await vault.reservePool()).toString(),
+        );
+        AssertHelpers.assertAlmostEqual(
+          deposit
+            .add(interest.sub(reservePool))
+            .add(interest.sub(reservePool).mul(13).div(10))
+            .add(interest.sub(reservePool).mul(13).div(10)).toString(),
+          (await vault.totalToken()).toString(),
+        );
+        expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
+        expect(await alpacaToken.balanceOf(await alice.getAddress())).to.be.bignumber.gt(aliceAlpacaBefore);
   
-      //   // Alice creates a new position again
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     ethers.utils.parseEther('1'),
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   )
-      //   // She can close position
-      //   await vaultAsAlice.work(
-      //     2,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '115792089237316195423570985008687907853269984665640564039457584007913129639935',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
-      // }).timeout(50000);
+        // Alice creates a new position again
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          ethers.utils.parseEther('1'),
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        )
+        // She can close position
+        await vaultAsAlice.work(
+          2,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
+      }).timeout(50000);
   
-      // it('should be not allow user to emergencyWithdraw debtToken on FairLaunch', async () => {
-      //   // Deployer deposits 3 BTOKEN to the bank
-      //   const deposit = ethers.utils.parseEther('3');
-      //   await baseToken.approve(vault.address, deposit);
-      //   await vault.deposit(deposit);
+      it('should be not allow user to emergencyWithdraw debtToken on FairLaunch', async () => {
+        // Deployer deposits 3 BTOKEN to the bank
+        const deposit = ethers.utils.parseEther('3');
+        await baseToken.approve(vault.address, deposit);
+        await vault.deposit(deposit);
   
-      //   // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
-      //   const loan = ethers.utils.parseEther('1');
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     loan,
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Now Alice can take 1 BTOKEN loan + 1 BTOKEN of her to create a new position
+        const loan = ethers.utils.parseEther('1');
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          loan,
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
   
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   await vault.deposit(0); // Random action to trigger interest computation
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await pancakeswapV2WorkerAsEve.reinvest();
+        await vault.deposit(0); // Random action to trigger interest computation
   
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
   
-      //   await vault.deposit(0); // Random action to trigger interest computation
-      //   const interest = ethers.utils.parseEther('0.3'); //30% interest rate
-      //   const reservePool = interest.mul(RESERVE_POOL_BPS).div('10000');
-      //   AssertHelpers.assertAlmostEqual(
-      //     (deposit
-      //       .add(interest.sub(reservePool))
-      //       .add(interest.sub(reservePool).mul(13).div(10))
-      //       .add(interest.sub(reservePool).mul(13).div(10))).toString(),
-      //     (await vault.totalToken()).toString()
-      //   );
+        await vault.deposit(0); // Random action to trigger interest computation
+        const interest = ethers.utils.parseEther('0.3'); //30% interest rate
+        const reservePool = interest.mul(RESERVE_POOL_BPS).div('10000');
+        AssertHelpers.assertAlmostEqual(
+          (deposit
+            .add(interest.sub(reservePool))
+            .add(interest.sub(reservePool).mul(13).div(10))
+            .add(interest.sub(reservePool).mul(13).div(10))).toString(),
+          (await vault.totalToken()).toString()
+        );
   
-      //   // Alice emergencyWithdraw from FairLaunch
-      //   await expect(fairLaunchAsAlice.emergencyWithdraw(0)).to.be.revertedWith('only funder');
+        // Alice emergencyWithdraw from FairLaunch
+        await expect(fairLaunchAsAlice.emergencyWithdraw(0)).to.be.revertedWith('only funder');
   
-      //   const eveBefore = await baseToken.balanceOf(await eve.getAddress());
+        const eveBefore = await baseToken.balanceOf(await eve.getAddress());
   
-      //   // Now you can liquidate because of the insane interest rate
-      //   await expect(vaultAsEve.kill('1'))
-      //     .to.emit(vaultAsEve, 'Kill')
+        // Now you can liquidate because of the insane interest rate
+        await expect(vaultAsEve.kill('1'))
+          .to.emit(vaultAsEve, 'Kill')
   
-      //   expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
-      //   AssertHelpers.assertAlmostEqual(
-      //     deposit
-      //       .add(interest)
-      //       .add(interest.mul(13).div(10))
-      //       .add(interest.mul(13).div(10)).toString(),
-      //     (await baseToken.balanceOf(vault.address)).toString(),
-      //   );
-      //   expect(await vault.vaultDebtVal()).to.be.bignumber.eq(ethers.utils.parseEther('0'));
-      //   AssertHelpers.assertAlmostEqual(
-      //     reservePool.add(reservePool.mul(13).div(10)).add(reservePool.mul(13).div(10)).toString(),
-      //     (await vault.reservePool()).toString(),
-      //   );
-      //   AssertHelpers.assertAlmostEqual(
-      //     deposit
-      //       .add(interest.sub(reservePool))
-      //       .add(interest.sub(reservePool).mul(13).div(10))
-      //       .add(interest.sub(reservePool).mul(13).div(10)).toString(),
-      //     (await vault.totalToken()).toString(),
-      //   );
+        expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
+        AssertHelpers.assertAlmostEqual(
+          deposit
+            .add(interest)
+            .add(interest.mul(13).div(10))
+            .add(interest.mul(13).div(10)).toString(),
+          (await baseToken.balanceOf(vault.address)).toString(),
+        );
+        expect(await vault.vaultDebtVal()).to.be.bignumber.eq(ethers.utils.parseEther('0'));
+        AssertHelpers.assertAlmostEqual(
+          reservePool.add(reservePool.mul(13).div(10)).add(reservePool.mul(13).div(10)).toString(),
+          (await vault.reservePool()).toString(),
+        );
+        AssertHelpers.assertAlmostEqual(
+          deposit
+            .add(interest.sub(reservePool))
+            .add(interest.sub(reservePool).mul(13).div(10))
+            .add(interest.sub(reservePool).mul(13).div(10)).toString(),
+          (await vault.totalToken()).toString(),
+        );
   
-      //   // Alice creates a new position again
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     ethers.utils.parseEther('1'),
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   )
+        // Alice creates a new position again
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'));
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          ethers.utils.parseEther('1'),
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        )
     
-      //   // She can close position
-      //   await vaultAsAlice.work(
-      //     2,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '115792089237316195423570985008687907853269984665640564039457584007913129639935',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
-      // }).timeout(50000);
+        // She can close position
+        await vaultAsAlice.work(
+          2,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
+      }).timeout(50000);
   
-      // it('should deposit and withdraw BTOKEN from Vault (bad debt case)', async () => {
-      //   // Deployer deposits 10 BTOKEN to the Vault
-      //   const deposit = ethers.utils.parseEther('10');
-      //   await baseToken.approve(vault.address, deposit)
-      //   await vault.deposit(deposit);
+      it('should deposit and withdraw BTOKEN from Vault (bad debt case)', async () => {
+        // Deployer deposits 10 BTOKEN to the Vault
+        const deposit = ethers.utils.parseEther('10');
+        await baseToken.approve(vault.address, deposit)
+        await vault.deposit(deposit);
     
-      //   expect(await vault.balanceOf(await deployer.getAddress())).to.be.bignumber.equal(deposit);
+        expect(await vault.balanceOf(await deployer.getAddress())).to.be.bignumber.equal(deposit);
     
-      //   // Bob borrows 2 BTOKEN loan
-      //   const loan = ethers.utils.parseEther('2');
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('1'));
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     loan,
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Bob borrows 2 BTOKEN loan
+        const loan = ethers.utils.parseEther('2');
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('1'));
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          loan,
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   expect(await baseToken.balanceOf(vault.address)).to.be.bignumber.equal(deposit.sub(loan));
-      //   expect(await vault.vaultDebtVal()).to.be.bignumber.equal(loan);
-      //   expect(await vault.totalToken()).to.be.bignumber.equal(deposit);
+        expect(await baseToken.balanceOf(vault.address)).to.be.bignumber.equal(deposit.sub(loan));
+        expect(await vault.vaultDebtVal()).to.be.bignumber.equal(loan);
+        expect(await vault.totalToken()).to.be.bignumber.equal(deposit);
     
-      //   // Alice deposits 2 BTOKEN
-      //   const aliceDeposit = ethers.utils.parseEther('2');
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('2'));
-      //   await vaultAsAlice.deposit(aliceDeposit);
+        // Alice deposits 2 BTOKEN
+        const aliceDeposit = ethers.utils.parseEther('2');
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('2'));
+        await vaultAsAlice.deposit(aliceDeposit);
     
-      //   AssertHelpers.assertAlmostEqual(
-      //     deposit.sub(loan).add(aliceDeposit).toString(),
-      //     (await baseToken.balanceOf(vault.address)).toString(),
-      //   );
+        AssertHelpers.assertAlmostEqual(
+          deposit.sub(loan).add(aliceDeposit).toString(),
+          (await baseToken.balanceOf(vault.address)).toString(),
+        );
     
-      //   // check Alice ibBTOKEN balance = 2/10 * 10 = 2 ibBTOKEN
-      //   AssertHelpers.assertAlmostEqual(
-      //     aliceDeposit.toString(),
-      //     (await vault.balanceOf(await alice.getAddress())).toString(),
-      //   );
-      //   AssertHelpers.assertAlmostEqual(
-      //     deposit.add(aliceDeposit).toString(),
-      //     (await vault.totalSupply()).toString(),
-      //   );
+        // check Alice ibBTOKEN balance = 2/10 * 10 = 2 ibBTOKEN
+        AssertHelpers.assertAlmostEqual(
+          aliceDeposit.toString(),
+          (await vault.balanceOf(await alice.getAddress())).toString(),
+        );
+        AssertHelpers.assertAlmostEqual(
+          deposit.add(aliceDeposit).toString(),
+          (await vault.totalSupply()).toString(),
+        );
     
-      //   // Simulate BTOKEN price is very high by swap FTOKEN to BTOKEN (reduce BTOKEN supply)
-      //   await farmToken.mint(await deployer.getAddress(), ethers.utils.parseEther('100'));
-      //   await farmToken.approve(routerV2.address, ethers.utils.parseEther('100'));
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('100'), '0',
-      //     [farmToken.address, baseToken.address], await deployer.getAddress(), FOREVER);
+        // Simulate BTOKEN price is very high by swap FTOKEN to BTOKEN (reduce BTOKEN supply)
+        await farmToken.mint(await deployer.getAddress(), ethers.utils.parseEther('100'));
+        await farmToken.approve(routerV2.address, ethers.utils.parseEther('100'));
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('100'), '0',
+          [farmToken.address, baseToken.address], await deployer.getAddress(), FOREVER);
     
-      //   // Alice liquidates Bob position#1
-      //   let aliceBefore = await baseToken.balanceOf(await alice.getAddress());
+        // Alice liquidates Bob position#1
+        let aliceBefore = await baseToken.balanceOf(await alice.getAddress());
   
-      //   await expect(vaultAsAlice.kill('1'))
-      //     .to.emit(vaultAsAlice, 'Kill')
+        await expect(vaultAsAlice.kill('1'))
+          .to.emit(vaultAsAlice, 'Kill')
   
-      //   let aliceAfter = await baseToken.balanceOf(await alice.getAddress());
+        let aliceAfter = await baseToken.balanceOf(await alice.getAddress());
   
-      //   // Bank balance is increase by liquidation
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10.002702699312215556').toString(),
-      //     (await baseToken.balanceOf(vault.address)).toString(),
-      //   );
-      //   // Alice is liquidator, Alice should receive 10% Kill prize
-      //   // BTOKEN back from liquidation 0.00300199830261993, 10% of it is 0.000300199830261993
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.000300199830261993').toString(),
-      //     aliceAfter.sub(aliceBefore).toString(),
-      //   );
+        // Bank balance is increase by liquidation
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10.002702699312215556').toString(),
+          (await baseToken.balanceOf(vault.address)).toString(),
+        );
+        // Alice is liquidator, Alice should receive 10% Kill prize
+        // BTOKEN back from liquidation 0.00300199830261993, 10% of it is 0.000300199830261993
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.000300199830261993').toString(),
+          aliceAfter.sub(aliceBefore).toString(),
+        );
     
-      //   // Alice withdraws 2 BOKTEN
-      //   aliceBefore = await baseToken.balanceOf(await alice.getAddress());
-      //   await vaultAsAlice.withdraw(await vault.balanceOf(await alice.getAddress()));
-      //   aliceAfter = await baseToken.balanceOf(await alice.getAddress());
+        // Alice withdraws 2 BOKTEN
+        aliceBefore = await baseToken.balanceOf(await alice.getAddress());
+        await vaultAsAlice.withdraw(await vault.balanceOf(await alice.getAddress()));
+        aliceAfter = await baseToken.balanceOf(await alice.getAddress());
     
-      //   // alice gots 2/12 * 10.002702699312215556 = 1.667117116552036
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('1.667117116552036').toString(),
-      //     aliceAfter.sub(aliceBefore).toString()
-      //   );
-      // });
+        // alice gots 2/12 * 10.002702699312215556 = 1.667117116552036
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('1.667117116552036').toString(),
+          aliceAfter.sub(aliceBefore).toString()
+        );
+      });
   
-      // it('should liquidate user position correctly', async () => {
-      //   // Bob deposits 20 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('20'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('20'));
+      it('should liquidate user position correctly', async () => {
+        // Bob deposits 20 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('20'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('20'));
     
-      //   // Position#1: Alice borrows 10 BTOKEN loan
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Position#1: Alice borrows 10 BTOKEN loan
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   await farmToken.mint(await deployer.getAddress(), ethers.utils.parseEther('100'));
-      //   await farmToken.approve(routerV2.address, ethers.utils.parseEther('100'));
+        await farmToken.mint(await deployer.getAddress(), ethers.utils.parseEther('100'));
+        await farmToken.approve(routerV2.address, ethers.utils.parseEther('100'));
     
-      //   // Price swing 10%
-      //   // Add more token to the pool equals to sqrt(10*((0.1)**2) / 9) - 0.1 = 0.005409255338945984, (0.1 is the balance of token in the pool)
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('0.005409255338945984'),
-      //     '0',
-      //     [farmToken.address, baseToken.address],
-      //     await deployer.getAddress(),
-      //     FOREVER
-      //   );
-      //   await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
+        // Price swing 10%
+        // Add more token to the pool equals to sqrt(10*((0.1)**2) / 9) - 0.1 = 0.005409255338945984, (0.1 is the balance of token in the pool)
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('0.005409255338945984'),
+          '0',
+          [farmToken.address, baseToken.address],
+          await deployer.getAddress(),
+          FOREVER
+        );
+        await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
     
-      //   // Price swing 20%
-      //   // Add more token to the pool equals to
-      //   // sqrt(10*((0.10540925533894599)**2) / 8) - 0.10540925533894599 = 0.012441874858811944
-      //   // (0.10540925533894599 is the balance of token in the pool)
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('0.012441874858811944'),
-      //     '0',
-      //     [farmToken.address, baseToken.address],
-      //     await deployer.getAddress(),
-      //     FOREVER
-      //   );
-      //   await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
+        // Price swing 20%
+        // Add more token to the pool equals to
+        // sqrt(10*((0.10540925533894599)**2) / 8) - 0.10540925533894599 = 0.012441874858811944
+        // (0.10540925533894599 is the balance of token in the pool)
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('0.012441874858811944'),
+          '0',
+          [farmToken.address, baseToken.address],
+          await deployer.getAddress(),
+          FOREVER
+        );
+        await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
     
-      //   // Price swing 23.43%
-      //   // Existing token on the pool = 0.10540925533894599 + 0.012441874858811944 = 0.11785113019775793
-      //   // Add more token to the pool equals to
-      //   // sqrt(10*((0.11785113019775793)**2) / 7.656999999999999) - 0.11785113019775793 = 0.016829279312591913
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('0.016829279312591913'),
-      //     '0',
-      //     [farmToken.address, baseToken.address],
-      //     await deployer.getAddress(),
-      //     FOREVER
-      //   );
-      //   await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
+        // Price swing 23.43%
+        // Existing token on the pool = 0.10540925533894599 + 0.012441874858811944 = 0.11785113019775793
+        // Add more token to the pool equals to
+        // sqrt(10*((0.11785113019775793)**2) / 7.656999999999999) - 0.11785113019775793 = 0.016829279312591913
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('0.016829279312591913'),
+          '0',
+          [farmToken.address, baseToken.address],
+          await deployer.getAddress(),
+          FOREVER
+        );
+        await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
     
-      //   // Price swing 30%
-      //   // Existing token on the pool = 0.11785113019775793 + 0.016829279312591913 = 0.13468040951034985
-      //   // Add more token to the pool equals to
-      //   // sqrt(10*((0.13468040951034985)**2) / 7) - 0.13468040951034985 = 0.026293469053292218
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('0.026293469053292218'),
-      //     '0',
-      //     [farmToken.address, baseToken.address],
-      //     await deployer.getAddress(),
-      //     FOREVER
-      //   );
+        // Price swing 30%
+        // Existing token on the pool = 0.11785113019775793 + 0.016829279312591913 = 0.13468040951034985
+        // Add more token to the pool equals to
+        // sqrt(10*((0.13468040951034985)**2) / 7) - 0.13468040951034985 = 0.026293469053292218
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('0.026293469053292218'),
+          '0',
+          [farmToken.address, baseToken.address],
+          await deployer.getAddress(),
+          FOREVER
+        );
   
-      //   // Now you can liquidate because of the price fluctuation
-      //   const eveBefore = await baseToken.balanceOf(await eve.getAddress());
-      //   await expect(vaultAsEve.kill('1'))
-      //     .to.emit(vaultAsEve, 'Kill')
+        // Now you can liquidate because of the price fluctuation
+        const eveBefore = await baseToken.balanceOf(await eve.getAddress());
+        await expect(vaultAsEve.kill('1'))
+          .to.emit(vaultAsEve, 'Kill')
   
-      //   expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
-      // });
+        expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
+      });
   
-      // it('should reinvest correctly', async () => {
-      //   // Set Bank's debt interests to 0% per year
-      //   await simpleVaultConfig.setParams(
-      //     ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
-      //     '0', // 0% per year
-      //     '1000', // 10% reserve pool
-      //     '1000', // 10% Kill prize
-      //     wbnb.address,
-      //     wNativeRelayer.address,
-      //     fairLaunch.address,
-      //   );
+      it('should reinvest correctly', async () => {
+        // Set Bank's debt interests to 0% per year
+        await simpleVaultConfig.setParams(
+          ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
+          '0', // 0% per year
+          '1000', // 10% reserve pool
+          '1000', // 10% Kill prize
+          wbnb.address,
+          wNativeRelayer.address,
+          fairLaunch.address,
+        );
     
-      //   // Set Reinvest bounty to 10% of the reward
-      //   await pancakeswapV2Worker.setReinvestConfig('100', '0', [cake.address, wbnb.address, baseToken.address]);
+        // Set Reinvest bounty to 10% of the reward
+        await pancakeswapV2Worker.setReinvestConfig('100', '0', [cake.address, wbnb.address, baseToken.address]);
     
-      //   // Bob deposits 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('10'));
+        // Bob deposits 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('10'));
     
-      //   // Alice deposits 12 BTOKEN
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('12'));
-      //   await vaultAsAlice.deposit(ethers.utils.parseEther('12'));
+        // Alice deposits 12 BTOKEN
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('12'));
+        await vaultAsAlice.deposit(ethers.utils.parseEther('12'));
     
-      //   // Position#1: Bob borrows 10 BTOKEN loan
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return NATIVE to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Position#1: Bob borrows 10 BTOKEN loan
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return NATIVE to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
     
-      //   // Position#2: Alice borrows 2 BTOKEN loan
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'))
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     ethers.utils.parseEther('2'),
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Position#2: Alice borrows 2 BTOKEN loan
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'))
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          ethers.utils.parseEther('2'),
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   // ---------------- Reinvest#1 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        // ---------------- Reinvest#1 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
     
-      //   let [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   // PancakeWorker receives 303999999998816250 cake as a reward
-      //   // Eve got 10% of 303999999998816250 cake = 0.01 * 303999999998816250 = 3039999999988162 bounty
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.003039999999988162').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        let [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
+        // PancakeWorker receives 303999999998816250 cake as a reward
+        // Eve got 10% of 303999999998816250 cake = 0.01 * 303999999998816250 = 3039999999988162 bounty
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.003039999999988162').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
     
-      //   // Remaining PancakeWorker reward = 227999999998874730 - 22799999999887473 = 205199999998987257 (~90% reward)
-      //   // Convert 205199999998987257 cake to 671683776318381694 NATIVE
-      //   // Convert NATIVE to 1252466339860712438 LP token and stake
-      //   let [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // Remaining PancakeWorker reward = 227999999998874730 - 22799999999887473 = 205199999998987257 (~90% reward)
+        // Convert 205199999998987257 cake to 671683776318381694 NATIVE
+        // Convert NATIVE to 1252466339860712438 LP token and stake
+        let [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
     
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
     
-      //   // Check Bob position info
-      //   await pancakeswapV2Worker.health('1');
-      //   let [bobHealth, bobDebtToShare] = await vault.positionInfo('1');
-      //   expect(bobHealth).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10').toString(),
-      //     bobDebtToShare.toString(),
-      //   );
+        // Check Bob position info
+        await pancakeswapV2Worker.health('1');
+        let [bobHealth, bobDebtToShare] = await vault.positionInfo('1');
+        expect(bobHealth).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10').toString(),
+          bobDebtToShare.toString(),
+        );
     
-      //   // Check Alice position info
-      //   await pancakeswapV2Worker.health('2');
-      //   let [aliceHealth, aliceDebtToShare] = await vault.positionInfo('2');
-      //   expect(aliceHealth).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('2').toString(),
-      //     aliceDebtToShare.toString(),
-      //   );
+        // Check Alice position info
+        await pancakeswapV2Worker.health('2');
+        let [aliceHealth, aliceDebtToShare] = await vault.positionInfo('2');
+        expect(aliceHealth).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('2').toString(),
+          aliceDebtToShare.toString(),
+        );
     
-      //   // ---------------- Reinvest#2 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        // ---------------- Reinvest#2 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
     
-      //   [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
+        [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
     
-      //   // eve should earn cake as a reward for reinvest
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.004559999999987660').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        // eve should earn cake as a reward for reinvest
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.004559999999987660').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
     
-      //   // Remaining Worker reward = 142858796296283038 - 14285879629628304 = 128572916666654734 (~90% reward)
-      //   // Convert 128572916666654734 uni to 157462478899282341 NATIVE
-      //   // Convert NATIVE to 5001669421841640 LP token
-      //   [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
+        // Remaining Worker reward = 142858796296283038 - 14285879629628304 = 128572916666654734 (~90% reward)
+        // Convert 128572916666654734 uni to 157462478899282341 NATIVE
+        // Convert NATIVE to 5001669421841640 LP token
+        [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
     
-      //   // Check Bob position info
-      //   [bobHealth, bobDebtToShare] = await vault.positionInfo('1');
-      //   expect(bobHealth).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10').toString(),
-      //     bobDebtToShare.toString(),
-      //   );
+        // Check Bob position info
+        [bobHealth, bobDebtToShare] = await vault.positionInfo('1');
+        expect(bobHealth).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10').toString(),
+          bobDebtToShare.toString(),
+        );
     
-      //   // Check Alice position info
-      //   [aliceHealth, aliceDebtToShare] = await vault.positionInfo('2');
-      //   expect(aliceHealth).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('2').toString(),
-      //     aliceDebtToShare.toString(),
-      //   );
+        // Check Alice position info
+        [aliceHealth, aliceDebtToShare] = await vault.positionInfo('2');
+        expect(aliceHealth).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('2').toString(),
+          aliceDebtToShare.toString(),
+        );
     
-      //   // ---------------- Reinvest#3 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        // ---------------- Reinvest#3 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
     
-      //   [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
+        [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
     
-      //   // eve should earn cake as a reward for reinvest
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.006079999999979926').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        // eve should earn cake as a reward for reinvest
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.006079999999979926').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
     
-      //   // Remaining Worker reward = 142858796296283038 - 14285879629628304 = 128572916666654734 (~90% reward)
-      //   // Convert 128572916666654734 uni to 74159218067697746 NATIVE
-      //   // Convert NATIVE to 2350053120029788 LP token
-      //   [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
+        // Remaining Worker reward = 142858796296283038 - 14285879629628304 = 128572916666654734 (~90% reward)
+        // Convert 128572916666654734 uni to 74159218067697746 NATIVE
+        // Convert NATIVE to 2350053120029788 LP token
+        [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
     
-      //   const bobBefore = await baseToken.balanceOf(await bob.getAddress());
-      //   // Bob close position#1
-      //   await vaultAsBob.work(
-      //     1,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '1000000000000000000000',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
-      //   const bobAfter = await baseToken.balanceOf(await bob.getAddress());
+        const bobBefore = await baseToken.balanceOf(await bob.getAddress());
+        // Bob close position#1
+        await vaultAsBob.work(
+          1,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '1000000000000000000000',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
+        const bobAfter = await baseToken.balanceOf(await bob.getAddress());
     
-      //   // Check Bob account, Bob must be richer as he earn more from yield
-      //   expect(bobAfter).to.be.bignumber.gt(bobBefore);
+        // Check Bob account, Bob must be richer as he earn more from yield
+        expect(bobAfter).to.be.bignumber.gt(bobBefore);
     
-      //   // Alice add another 10 BTOKEN
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsAlice.work(
-      //     2,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     0,
-      //     '0', // max return = 0, don't return NATIVE to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Alice add another 10 BTOKEN
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsAlice.work(
+          2,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          0,
+          '0', // max return = 0, don't return NATIVE to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   const aliceBefore = await baseToken.balanceOf(await alice.getAddress());
-      //   // Alice close position#2
-      //   await vaultAsAlice.work(
-      //     2,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '1000000000000000000000000000000',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
-      //   const aliceAfter = await baseToken.balanceOf(await alice.getAddress());
+        const aliceBefore = await baseToken.balanceOf(await alice.getAddress());
+        // Alice close position#2
+        await vaultAsAlice.work(
+          2,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '1000000000000000000000000000000',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
+        const aliceAfter = await baseToken.balanceOf(await alice.getAddress());
     
-      //   // Check Alice account, Alice must be richer as she earned from leverage yield farm without getting liquidated
-      //   expect(aliceAfter).to.be.bignumber.gt(aliceBefore);
-      // }).timeout(50000);
+        // Check Alice account, Alice must be richer as she earned from leverage yield farm without getting liquidated
+        expect(aliceAfter).to.be.bignumber.gt(aliceBefore);
+      }).timeout(50000);
   
-      // it('should liquidate user position correctly', async () => {
-      //   // Bob deposits 20 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('20'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('20'));
+      it('should liquidate user position correctly', async () => {
+        // Bob deposits 20 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('20'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('20'));
     
-      //   // Position#1: Alice borrows 10 BTOKEN loan
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Position#1: Alice borrows 10 BTOKEN loan
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   await farmToken.mint(await deployer.getAddress(), ethers.utils.parseEther('100'));
-      //   await farmToken.approve(routerV2.address, ethers.utils.parseEther('100'));
+        await farmToken.mint(await deployer.getAddress(), ethers.utils.parseEther('100'));
+        await farmToken.approve(routerV2.address, ethers.utils.parseEther('100'));
     
-      //   // Price swing 10%
-      //   // Add more token to the pool equals to sqrt(10*((0.1)**2) / 9) - 0.1 = 0.005409255338945984, (0.1 is the balance of token in the pool)
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('0.005409255338945984'),
-      //     '0',
-      //     [farmToken.address, baseToken.address],
-      //     await deployer.getAddress(),
-      //     FOREVER
-      //   );
-      //   await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
+        // Price swing 10%
+        // Add more token to the pool equals to sqrt(10*((0.1)**2) / 9) - 0.1 = 0.005409255338945984, (0.1 is the balance of token in the pool)
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('0.005409255338945984'),
+          '0',
+          [farmToken.address, baseToken.address],
+          await deployer.getAddress(),
+          FOREVER
+        );
+        await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
     
-      //   // Price swing 20%
-      //   // Add more token to the pool equals to
-      //   // sqrt(10*((0.10540925533894599)**2) / 8) - 0.10540925533894599 = 0.012441874858811944
-      //   // (0.10540925533894599 is the balance of token in the pool)
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('0.012441874858811944'),
-      //     '0',
-      //     [farmToken.address, baseToken.address],
-      //     await deployer.getAddress(),
-      //     FOREVER
-      //   );
-      //   await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
+        // Price swing 20%
+        // Add more token to the pool equals to
+        // sqrt(10*((0.10540925533894599)**2) / 8) - 0.10540925533894599 = 0.012441874858811944
+        // (0.10540925533894599 is the balance of token in the pool)
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('0.012441874858811944'),
+          '0',
+          [farmToken.address, baseToken.address],
+          await deployer.getAddress(),
+          FOREVER
+        );
+        await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
     
-      //   // Price swing 23.43%
-      //   // Existing token on the pool = 0.10540925533894599 + 0.012441874858811944 = 0.11785113019775793
-      //   // Add more token to the pool equals to
-      //   // sqrt(10*((0.11785113019775793)**2) / 7.656999999999999) - 0.11785113019775793 = 0.016829279312591913
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('0.016829279312591913'),
-      //     '0',
-      //     [farmToken.address, baseToken.address],
-      //     await deployer.getAddress(),
-      //     FOREVER
-      //   );
-      //   await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
+        // Price swing 23.43%
+        // Existing token on the pool = 0.10540925533894599 + 0.012441874858811944 = 0.11785113019775793
+        // Add more token to the pool equals to
+        // sqrt(10*((0.11785113019775793)**2) / 7.656999999999999) - 0.11785113019775793 = 0.016829279312591913
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('0.016829279312591913'),
+          '0',
+          [farmToken.address, baseToken.address],
+          await deployer.getAddress(),
+          FOREVER
+        );
+        await expect(vaultAsEve.kill('1')).to.be.revertedWith("can't liquidate");
   
-      //   // Price swing 30%
-      //   // Existing token on the pool = 0.11785113019775793 + 0.016829279312591913 = 0.13468040951034985
-      //   // Add more token to the pool equals to
-      //   // sqrt(10*((0.13468040951034985)**2) / 7) - 0.13468040951034985 = 0.026293469053292218
-      //   await routerV2.swapExactTokensForTokens(
-      //     ethers.utils.parseEther('0.026293469053292218'),
-      //     '0',
-      //     [farmToken.address, baseToken.address],
-      //     await deployer.getAddress(),
-      //     FOREVER
-      //   );
+        // Price swing 30%
+        // Existing token on the pool = 0.11785113019775793 + 0.016829279312591913 = 0.13468040951034985
+        // Add more token to the pool equals to
+        // sqrt(10*((0.13468040951034985)**2) / 7) - 0.13468040951034985 = 0.026293469053292218
+        await routerV2.swapExactTokensForTokens(
+          ethers.utils.parseEther('0.026293469053292218'),
+          '0',
+          [farmToken.address, baseToken.address],
+          await deployer.getAddress(),
+          FOREVER
+        );
   
-      //   // Now you can liquidate because of the price fluctuation
-      //   const eveBefore = await baseToken.balanceOf(await eve.getAddress());
-      //   await expect(vaultAsEve.kill('1'))
-      //     .to.emit(vaultAsEve, 'Kill')
-      //   expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
-      // });
+        // Now you can liquidate because of the price fluctuation
+        const eveBefore = await baseToken.balanceOf(await eve.getAddress());
+        await expect(vaultAsEve.kill('1'))
+          .to.emit(vaultAsEve, 'Kill')
+        expect(await baseToken.balanceOf(await eve.getAddress())).to.be.bignumber.gt(eveBefore);
+      });
   
-      // it('should close position correctly when user holds multiple positions', async () => {
-      //   // Set Bank's debt interests to 0% per year
-      //   await simpleVaultConfig.setParams(
-      //     ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
-      //     '0', // 0% per year
-      //     '1000', // 10% reserve pool
-      //     '1000', // 10% Kill prize
-      //     wbnb.address,
-      //     wNativeRelayer.address,
-      //     fairLaunch.address,
-      //   );
+      it('should close position correctly when user holds multiple positions', async () => {
+        // Set Bank's debt interests to 0% per year
+        await simpleVaultConfig.setParams(
+          ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
+          '0', // 0% per year
+          '1000', // 10% reserve pool
+          '1000', // 10% Kill prize
+          wbnb.address,
+          wNativeRelayer.address,
+          fairLaunch.address,
+        );
   
-      //   // Set Reinvest bounty to 10% of the reward
-      //   await pancakeswapV2Worker.setReinvestConfig('100', '0', [cake.address, wbnb.address, baseToken.address]);
+        // Set Reinvest bounty to 10% of the reward
+        await pancakeswapV2Worker.setReinvestConfig('100', '0', [cake.address, wbnb.address, baseToken.address]);
   
-      //   // Bob deposits 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('10'));
+        // Bob deposits 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('10'));
   
-      //   // Alice deposits 12 BTOKEN
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('12'));
-      //   await vaultAsAlice.deposit(ethers.utils.parseEther('12'));
+        // Alice deposits 12 BTOKEN
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('12'));
+        await vaultAsAlice.deposit(ethers.utils.parseEther('12'));
   
-      //   // Position#1: Bob borrows 10 BTOKEN loan
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return NATIVE to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Position#1: Bob borrows 10 BTOKEN loan
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return NATIVE to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
   
-      //   // Position#2: Bob borrows another 2 BTOKEN loan
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('1'))
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     ethers.utils.parseEther('2'),
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Position#2: Bob borrows another 2 BTOKEN loan
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('1'))
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          ethers.utils.parseEther('2'),
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
   
-      //   // ---------------- Reinvest#1 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        // ---------------- Reinvest#1 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
   
-      //   let [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   // PancakeWorker receives 303999999998816250 cake as a reward
-      //   // Eve got 10% of 303999999998816250 cake = 0.01 * 303999999998816250 = 3039999999988162 bounty
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.003039999999988162').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        let [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
+        // PancakeWorker receives 303999999998816250 cake as a reward
+        // Eve got 10% of 303999999998816250 cake = 0.01 * 303999999998816250 = 3039999999988162 bounty
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.003039999999988162').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
   
-      //   // Remaining PancakeWorker reward = 227999999998874730 - 22799999999887473 = 205199999998987257 (~90% reward)
-      //   // Convert 205199999998987257 cake to 671683776318381694 NATIVE
-      //   // Convert NATIVE to 1252466339860712438 LP token and stake
-      //   let [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // Remaining PancakeWorker reward = 227999999998874730 - 22799999999887473 = 205199999998987257 (~90% reward)
+        // Convert 205199999998987257 cake to 671683776318381694 NATIVE
+        // Convert NATIVE to 1252466339860712438 LP token and stake
+        let [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
   
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
   
-      //   // Check Position#1 info
-      //   await pancakeswapV2Worker.health('1');
-      //   let [bob1Health, bob1DebtToShare] = await vault.positionInfo('1');
-      //   expect(bob1Health).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10').toString(),
-      //     bob1DebtToShare.toString(),
-      //   );
+        // Check Position#1 info
+        await pancakeswapV2Worker.health('1');
+        let [bob1Health, bob1DebtToShare] = await vault.positionInfo('1');
+        expect(bob1Health).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10').toString(),
+          bob1DebtToShare.toString(),
+        );
   
-      //   // Check Position#2 info
-      //   await pancakeswapV2Worker.health('2');
-      //   let [bob2Health, bob2DebtToShare] = await vault.positionInfo('2');
-      //   expect(bob2Health).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('2').toString(),
-      //     bob2DebtToShare.toString(),
-      //   );
+        // Check Position#2 info
+        await pancakeswapV2Worker.health('2');
+        let [bob2Health, bob2DebtToShare] = await vault.positionInfo('2');
+        expect(bob2Health).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('2').toString(),
+          bob2DebtToShare.toString(),
+        );
   
-      //   // ---------------- Reinvest#2 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        // ---------------- Reinvest#2 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
   
-      //   [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
+        [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
   
-      //   // eve should earn cake as a reward for reinvest
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.004559999999987660').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        // eve should earn cake as a reward for reinvest
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.004559999999987660').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
   
-      //   // Remaining Worker reward = 142858796296283038 - 14285879629628304 = 128572916666654734 (~90% reward)
-      //   // Convert 128572916666654734 uni to 157462478899282341 NATIVE
-      //   // Convert NATIVE to 5001669421841640 LP token
-      //   [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
+        // Remaining Worker reward = 142858796296283038 - 14285879629628304 = 128572916666654734 (~90% reward)
+        // Convert 128572916666654734 uni to 157462478899282341 NATIVE
+        // Convert NATIVE to 5001669421841640 LP token
+        [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
   
-      //   // Check Position#1 position info
-      //   [bob1Health, bob1DebtToShare] = await vault.positionInfo('1');
-      //   expect(bob1Health).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10').toString(),
-      //     bob1DebtToShare.toString(),
-      //   );
+        // Check Position#1 position info
+        [bob1Health, bob1DebtToShare] = await vault.positionInfo('1');
+        expect(bob1Health).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10').toString(),
+          bob1DebtToShare.toString(),
+        );
   
-      //   // Check Position#2 position info
-      //   [bob2Health, bob2DebtToShare] = await vault.positionInfo('2');
-      //   expect(bob2Health).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('2').toString(),
-      //     bob2DebtToShare.toString(),
-      //   );
+        // Check Position#2 position info
+        [bob2Health, bob2DebtToShare] = await vault.positionInfo('2');
+        expect(bob2Health).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('2').toString(),
+          bob2DebtToShare.toString(),
+        );
   
-      //   let bobBefore = await baseToken.balanceOf(await bob.getAddress());
-      //   let bobAlpacaBefore = await alpacaToken.balanceOf(await bob.getAddress());
-      //   // Bob close position#1
-      //   await vaultAsBob.work(
-      //     1,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '1000000000000000000000',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
-      //   let bobAfter = await baseToken.balanceOf(await bob.getAddress());
-      //   let bobAlpacaAfter = await alpacaToken.balanceOf(await bob.getAddress());
+        let bobBefore = await baseToken.balanceOf(await bob.getAddress());
+        let bobAlpacaBefore = await alpacaToken.balanceOf(await bob.getAddress());
+        // Bob close position#1
+        await vaultAsBob.work(
+          1,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '1000000000000000000000',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
+        let bobAfter = await baseToken.balanceOf(await bob.getAddress());
+        let bobAlpacaAfter = await alpacaToken.balanceOf(await bob.getAddress());
   
-      //   // Check Bob account, Bob must be richer as he earn more from yield
-      //   expect(bobAlpacaAfter).to.be.bignumber.gt(bobAlpacaBefore);
-      //   expect(bobAfter).to.be.bignumber.gt(bobBefore);
+        // Check Bob account, Bob must be richer as he earn more from yield
+        expect(bobAlpacaAfter).to.be.bignumber.gt(bobAlpacaBefore);
+        expect(bobAfter).to.be.bignumber.gt(bobBefore);
   
-      //   // Bob add another 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.work(
-      //     2,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     0,
-      //     '0', // max return = 0, don't return NATIVE to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Bob add another 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.work(
+          2,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          0,
+          '0', // max return = 0, don't return NATIVE to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   bobBefore = await baseToken.balanceOf(await bob.getAddress());
-      //   bobAlpacaBefore = await alpacaToken.balanceOf(await bob.getAddress());
-      //   // Bob close position#2
-      //   await vaultAsBob.work(
-      //     2,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '1000000000000000000000000000000',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
-      //   bobAfter = await baseToken.balanceOf(await bob.getAddress());
-      //   bobAlpacaAfter = await alpacaToken.balanceOf(await bob.getAddress());
+        bobBefore = await baseToken.balanceOf(await bob.getAddress());
+        bobAlpacaBefore = await alpacaToken.balanceOf(await bob.getAddress());
+        // Bob close position#2
+        await vaultAsBob.work(
+          2,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '1000000000000000000000000000000',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
+        bobAfter = await baseToken.balanceOf(await bob.getAddress());
+        bobAlpacaAfter = await alpacaToken.balanceOf(await bob.getAddress());
   
-      //   // Check Bob account, Bob must be richer as she earned from leverage yield farm without getting liquidated
-      //   expect(bobAfter).to.be.bignumber.gt(bobBefore);
-      //   expect(bobAlpacaAfter).to.be.bignumber.gt(bobAlpacaBefore);
-      // }).timeout(50000)
+        // Check Bob account, Bob must be richer as she earned from leverage yield farm without getting liquidated
+        expect(bobAfter).to.be.bignumber.gt(bobBefore);
+        expect(bobAlpacaAfter).to.be.bignumber.gt(bobAlpacaBefore);
+      }).timeout(50000)
   
-      // it('should close position correctly when user holds mix positions of leveraged and non-leveraged', async () => {
-      //   // Set Bank's debt interests to 0% per year
-      //   await simpleVaultConfig.setParams(
-      //     ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
-      //     '0', // 0% per year
-      //     '1000', // 10% reserve pool
-      //     '1000', // 10% Kill prize
-      //     wbnb.address,
-      //     wNativeRelayer.address,
-      //     fairLaunch.address,
-      //   );
+      it('should close position correctly when user holds mix positions of leveraged and non-leveraged', async () => {
+        // Set Bank's debt interests to 0% per year
+        await simpleVaultConfig.setParams(
+          ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
+          '0', // 0% per year
+          '1000', // 10% reserve pool
+          '1000', // 10% Kill prize
+          wbnb.address,
+          wNativeRelayer.address,
+          fairLaunch.address,
+        );
     
-      //   // Set Reinvest bounty to 10% of the reward
-      //   await pancakeswapV2Worker.setReinvestConfig('100', '0', [cake.address, wbnb.address, baseToken.address]);
+        // Set Reinvest bounty to 10% of the reward
+        await pancakeswapV2Worker.setReinvestConfig('100', '0', [cake.address, wbnb.address, baseToken.address]);
     
-      //   // Bob deposits 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('10'));
+        // Bob deposits 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('10'));
     
-      //   // Alice deposits 12 BTOKEN
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('12'));
-      //   await vaultAsAlice.deposit(ethers.utils.parseEther('12'));
+        // Alice deposits 12 BTOKEN
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('12'));
+        await vaultAsAlice.deposit(ethers.utils.parseEther('12'));
     
-      //   // Position#1: Bob borrows 10 BTOKEN loan
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return NATIVE to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Position#1: Bob borrows 10 BTOKEN loan
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return NATIVE to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
     
-      //   // Position#2: Bob open position without leverage
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('3'))
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('3'),
-      //     '0',
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Position#2: Bob open position without leverage
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('3'))
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('3'),
+          '0',
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   // ---------------- Reinvest#1 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        // ---------------- Reinvest#1 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
     
-      //   let [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   // PancakeWorker receives 303999999998816250 cake as a reward
-      //   // Eve got 10% of 303999999998816250 cake = 0.01 * 303999999998816250 = 3039999999988162 bounty
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.003039999999988162').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        let [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
+        // PancakeWorker receives 303999999998816250 cake as a reward
+        // Eve got 10% of 303999999998816250 cake = 0.01 * 303999999998816250 = 3039999999988162 bounty
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.003039999999988162').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
     
-      //   // Remaining PancakeWorker reward = 227999999998874730 - 22799999999887473 = 205199999998987257 (~90% reward)
-      //   // Convert 205199999998987257 cake to 671683776318381694 NATIVE
-      //   // Convert NATIVE to 1252466339860712438 LP token and stake
-      //   let [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // Remaining PancakeWorker reward = 227999999998874730 - 22799999999887473 = 205199999998987257 (~90% reward)
+        // Convert 205199999998987257 cake to 671683776318381694 NATIVE
+        // Convert NATIVE to 1252466339860712438 LP token and stake
+        let [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
     
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
     
-      //   // Check Position#1 info
-      //   await pancakeswapV2Worker.health('1');
-      //   let [bob1Health, bob1DebtToShare] = await vault.positionInfo('1');
-      //   expect(bob1Health).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10').toString(),
-      //     bob1DebtToShare.toString(),
-      //   );
+        // Check Position#1 info
+        await pancakeswapV2Worker.health('1');
+        let [bob1Health, bob1DebtToShare] = await vault.positionInfo('1');
+        expect(bob1Health).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10').toString(),
+          bob1DebtToShare.toString(),
+        );
     
-      //   // Check Position#2 info
-      //   await pancakeswapV2Worker.health('2');
-      //   let [bob2Health, bob2DebtToShare] = await vault.positionInfo('2');
-      //   expect(bob2Health).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0').toString(),
-      //     bob2DebtToShare.toString(),
-      //   );
+        // Check Position#2 info
+        await pancakeswapV2Worker.health('2');
+        let [bob2Health, bob2DebtToShare] = await vault.positionInfo('2');
+        expect(bob2Health).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0').toString(),
+          bob2DebtToShare.toString(),
+        );
     
-      //   // ---------------- Reinvest#2 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        // ---------------- Reinvest#2 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
     
-      //   [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
+        [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
     
-      //   // eve should earn cake as a reward for reinvest
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.004559999999987660').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        // eve should earn cake as a reward for reinvest
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.004559999999987660').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
     
-      //   // Remaining Worker reward = 142858796296283038 - 14285879629628304 = 128572916666654734 (~90% reward)
-      //   // Convert 128572916666654734 uni to 157462478899282341 NATIVE
-      //   // Convert NATIVE to 5001669421841640 LP token
-      //   [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
+        // Remaining Worker reward = 142858796296283038 - 14285879629628304 = 128572916666654734 (~90% reward)
+        // Convert 128572916666654734 uni to 157462478899282341 NATIVE
+        // Convert NATIVE to 5001669421841640 LP token
+        [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(workerLPAfter).to.be.bignumber.gt(workerLPBefore);
     
-      //   // Check Position#1 position info
-      //   [bob1Health, bob1DebtToShare] = await vault.positionInfo('1');
-      //   expect(bob1Health).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10').toString(),
-      //     bob1DebtToShare.toString(),
-      //   );
+        // Check Position#1 position info
+        [bob1Health, bob1DebtToShare] = await vault.positionInfo('1');
+        expect(bob1Health).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10').toString(),
+          bob1DebtToShare.toString(),
+        );
     
-      //   // Check Position#2 position info
-      //   [bob2Health, bob2DebtToShare] = await vault.positionInfo('2');
-      //   expect(bob2Health).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0').toString(),
-      //     bob2DebtToShare.toString(),
-      //   );
+        // Check Position#2 position info
+        [bob2Health, bob2DebtToShare] = await vault.positionInfo('2');
+        expect(bob2Health).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0').toString(),
+          bob2DebtToShare.toString(),
+        );
     
-      //   let bobBefore = await baseToken.balanceOf(await bob.getAddress());
-      //   let bobAlpacaBefore = await alpacaToken.balanceOf(await bob.getAddress());
-      //   // Bob close position#1
-      //   await vaultAsBob.work(
-      //     1,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '1000000000000000000000',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
-      //   let bobAfter = await baseToken.balanceOf(await bob.getAddress());
-      //   let bobAlpacaAfter = await alpacaToken.balanceOf(await bob.getAddress());
+        let bobBefore = await baseToken.balanceOf(await bob.getAddress());
+        let bobAlpacaBefore = await alpacaToken.balanceOf(await bob.getAddress());
+        // Bob close position#1
+        await vaultAsBob.work(
+          1,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '1000000000000000000000',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
+        let bobAfter = await baseToken.balanceOf(await bob.getAddress());
+        let bobAlpacaAfter = await alpacaToken.balanceOf(await bob.getAddress());
     
-      //   // Check Bob account, Bob must be richer as he earn more from yield
-      //   expect(bobAlpacaAfter).to.be.bignumber.gt(bobAlpacaBefore);
-      //   expect(bobAfter).to.be.bignumber.gt(bobBefore);
+        // Check Bob account, Bob must be richer as he earn more from yield
+        expect(bobAlpacaAfter).to.be.bignumber.gt(bobAlpacaBefore);
+        expect(bobAfter).to.be.bignumber.gt(bobBefore);
     
-      //   // Bob add another 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.work(
-      //     2,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     0,
-      //     '0', // max return = 0, don't return NATIVE to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
+        // Bob add another 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.work(
+          2,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          0,
+          '0', // max return = 0, don't return NATIVE to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
     
-      //   bobBefore = await baseToken.balanceOf(await bob.getAddress());
-      //   bobAlpacaBefore = await alpacaToken.balanceOf(await bob.getAddress());
-      //   // Bob close position#2
-      //   await vaultAsBob.work(
-      //     2,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '1000000000000000000000000000000',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
-      //   bobAfter = await baseToken.balanceOf(await bob.getAddress());
-      //   bobAlpacaAfter = await alpacaToken.balanceOf(await bob.getAddress());
+        bobBefore = await baseToken.balanceOf(await bob.getAddress());
+        bobAlpacaBefore = await alpacaToken.balanceOf(await bob.getAddress());
+        // Bob close position#2
+        await vaultAsBob.work(
+          2,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '1000000000000000000000000000000',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [liqStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
+        bobAfter = await baseToken.balanceOf(await bob.getAddress());
+        bobAlpacaAfter = await alpacaToken.balanceOf(await bob.getAddress());
   
-      //   // Check Bob account, Bob must be richer as she earned from leverage yield farm without getting liquidated
-      //   // But bob shouldn't earn more ALPACAs from closing position#2
-      //   expect(bobAfter).to.be.bignumber.gt(bobBefore);
-      //   expect(bobAlpacaAfter).to.be.bignumber.eq(bobAlpacaBefore);
-      // }).timeout(50000)
+        // Check Bob account, Bob must be richer as she earned from leverage yield farm without getting liquidated
+        // But bob shouldn't earn more ALPACAs from closing position#2
+        expect(bobAfter).to.be.bignumber.gt(bobBefore);
+        expect(bobAlpacaAfter).to.be.bignumber.eq(bobAlpacaBefore);
+      }).timeout(50000)
   
-      // it('should partially close position successfully, when maxReturn < liquidated amount, payback part of the debt', async () => {
-      //   // Set Bank's debt interests to 0% per year
-      //   await simpleVaultConfig.setParams(
-      //     ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
-      //     '0', // 0% per year
-      //     '1000', // 10% reserve pool
-      //     '1000', // 10% Kill prize
-      //     wbnb.address,
-      //     wNativeRelayer.address,
-      //     fairLaunch.address,
-      //   );
+      it('should partially close position successfully, when maxReturn < liquidated amount, payback part of the debt', async () => {
+        // Set Bank's debt interests to 0% per year
+        await simpleVaultConfig.setParams(
+          ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
+          '0', // 0% per year
+          '1000', // 10% reserve pool
+          '1000', // 10% Kill prize
+          wbnb.address,
+          wNativeRelayer.address,
+          fairLaunch.address,
+        );
         
-      //   // Set Reinvest bounty to 10% of the reward
-      //   await pancakeswapV2Worker.setReinvestConfig('100', '0', [cake.address, wbnb.address, baseToken.address]);
+        // Set Reinvest bounty to 10% of the reward
+        await pancakeswapV2Worker.setReinvestConfig('100', '0', [cake.address, wbnb.address, baseToken.address]);
   
-      //   // Bob deposits 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('10'));
+        // Bob deposits 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('10'));
   
-      //   // Alice deposits 12 BTOKEN
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('12'));
-      //   await vaultAsAlice.deposit(ethers.utils.parseEther('12'));
+        // Alice deposits 12 BTOKEN
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('12'));
+        await vaultAsAlice.deposit(ethers.utils.parseEther('12'));
   
-      //   // Position#1: Bob borrows 10 BTOKEN loan and supply another 10 BToken
-      //   // Thus, Bob's position value will be worth 20 BTOKEN 
-      //   // After calling `work()` 
-      //   // 20 BTOKEN needs to swap 3.587061715703192586 BTOKEN to FTOKEN
-      //   // new reserve after swap will be 4.587061715703192586 0.021843151027158060
-      //   // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 16.412938284296807414 BTOKEN - 0.078156848972841940 FTOKEN
-      //   // new reserve after adding liquidity 21.000000000000000000 BTOKEN - 0.100000000000000000 FTOKEN
-      //   // lp amount from adding liquidity will be 1.131492691639043045 LP
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
-      //   let [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return NATIVE to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
-      //   let [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   expect(workerLPAfter.sub(workerLPBefore)).to.eq(parseEther('1.131492691639043045'))
+        // Position#1: Bob borrows 10 BTOKEN loan and supply another 10 BToken
+        // Thus, Bob's position value will be worth 20 BTOKEN 
+        // After calling `work()` 
+        // 20 BTOKEN needs to swap 3.587061715703192586 BTOKEN to FTOKEN
+        // new reserve after swap will be 4.587061715703192586 0.021843151027158060
+        // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 16.412938284296807414 BTOKEN - 0.078156848972841940 FTOKEN
+        // new reserve after adding liquidity 21.000000000000000000 BTOKEN - 0.100000000000000000 FTOKEN
+        // lp amount from adding liquidity will be 1.131492691639043045 LP
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
+        let [workerLPBefore, workerDebtBefore] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return NATIVE to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
+        let [workerLPAfter, workerDebtAfter] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        expect(workerLPAfter.sub(workerLPBefore)).to.eq(parseEther('1.131492691639043045'))
   
-      //   await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'))
-      //   // Position#2: Alice borrows 2 BTOKEN loan and supply 1 BTOKEN
-      //   // After calling `work()`, the `_reinvest()` is invoked
-      //   // since 2 blocks have passed since approve and work now reward will be 0.076 * 2 =~ 0.1519999999990075  CAKE
-      //   // reward without bounty will be 0.1519999999990075 - 0.001519999999991226 =~ 0.150479999999131439 CAKE
-      //   // 0.150479999999131439 CAKE can be converted into: 
-      //   // (0.150479999999131439 * 0.9975 * 1) / (0.1 + 0.150479999999131439 * 0.9975) = 0.6001660110722029 WBNB
-      //   // 0.6001660110722029 WBNB can be converted into (0.6001660110722029 * 0.9975 * 1) / (1 + 0.6001660110722029 * 0.9975) = 0.374478313366409272 BTOKEN
-      //   // based on optimal swap formula, 0.374478313366409272 BTOKEN needs to swap 0.186645098725751122 BTOKEN
-      //   // new reserve after swap will be 21.186645098725751122 0.099121226670953660
-      //   // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 0.187833214640658150 BTOKEN - 0.000878773329046340 FTOKEN
-      //   // new reserve after adding liquidity receiving from `_reinvest()` is 21.374478313366409272 BTOKEN - 0.100000000000000000 FTOKEN
-      //   // more LP amount after executing add strategy will be 0.012834971567957384 LP
-      //   // accumulated LP of the worker will be 1.131492691639043045 + 0.012834971567957384 = 1.1443276632070005 LP
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther('1'))
+        // Position#2: Alice borrows 2 BTOKEN loan and supply 1 BTOKEN
+        // After calling `work()`, the `_reinvest()` is invoked
+        // since 2 blocks have passed since approve and work now reward will be 0.076 * 2 =~ 0.1519999999990075  CAKE
+        // reward without bounty will be 0.1519999999990075 - 0.001519999999991226 =~ 0.150479999999131439 CAKE
+        // 0.150479999999131439 CAKE can be converted into: 
+        // (0.150479999999131439 * 0.9975 * 1) / (0.1 + 0.150479999999131439 * 0.9975) = 0.6001660110722029 WBNB
+        // 0.6001660110722029 WBNB can be converted into (0.6001660110722029 * 0.9975 * 1) / (1 + 0.6001660110722029 * 0.9975) = 0.374478313366409272 BTOKEN
+        // based on optimal swap formula, 0.374478313366409272 BTOKEN needs to swap 0.186645098725751122 BTOKEN
+        // new reserve after swap will be 21.186645098725751122 0.099121226670953660
+        // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 0.187833214640658150 BTOKEN - 0.000878773329046340 FTOKEN
+        // new reserve after adding liquidity receiving from `_reinvest()` is 21.374478313366409272 BTOKEN - 0.100000000000000000 FTOKEN
+        // more LP amount after executing add strategy will be 0.012834971567957384 LP
+        // accumulated LP of the worker will be 1.131492691639043045 + 0.012834971567957384 = 1.1443276632070005 LP
         
-      //   // alice supplying 3 BTOKEN to the pool
-      //   // based on optimal swap formula, 3 BTOKEN needs to swap for 1.452581363963336302 BTOKEN for 0.006348520022223796 FTOKEN
-      //   // new reserve after swap will be 22.827059677329745574 BTOKEN - 0.093651479977776204 FTOKEN
-      //   // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 1.547418636036663698 BTOKEN - 0.006348520022223796 FTOKEN
-      //   // new reserve after adding liquidity is 24.374478313366409272 BTOKEN - 0.100000000000000000 FTOKEN
-      //   // more LP amount after executing add strategy will be 0.099009277677144773 LP
-      //   // accumulated LP of the worker will be 1.1443276632070005 + 0.099009277677144773 = 1.2433369408841453 LP
-      //   let userInfoBefore = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await vaultAsAlice.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('1'),
-      //     ethers.utils.parseEther('2'),
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     )
-      //   );
-      //   let userInfoAfter = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(userInfoAfter.amount).to.be.bignumber.gt(userInfoBefore.amount);
-      //   expect(userInfoAfter.amount.sub(userInfoBefore.amount)).to.eq(parseEther('0.099009277677144773').add(parseEther('0.012834971567957384')))
+        // alice supplying 3 BTOKEN to the pool
+        // based on optimal swap formula, 3 BTOKEN needs to swap for 1.452581363963336302 BTOKEN for 0.006348520022223796 FTOKEN
+        // new reserve after swap will be 22.827059677329745574 BTOKEN - 0.093651479977776204 FTOKEN
+        // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 1.547418636036663698 BTOKEN - 0.006348520022223796 FTOKEN
+        // new reserve after adding liquidity is 24.374478313366409272 BTOKEN - 0.100000000000000000 FTOKEN
+        // more LP amount after executing add strategy will be 0.099009277677144773 LP
+        // accumulated LP of the worker will be 1.1443276632070005 + 0.099009277677144773 = 1.2433369408841453 LP
+        let userInfoBefore = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await vaultAsAlice.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('1'),
+          ethers.utils.parseEther('2'),
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          )
+        );
+        let userInfoAfter = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(userInfoAfter.amount).to.be.bignumber.gt(userInfoBefore.amount);
+        expect(userInfoAfter.amount.sub(userInfoBefore.amount)).to.eq(parseEther('0.099009277677144773').add(parseEther('0.012834971567957384')))
   
-      //   // ---------------- Reinvest#1 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        // ---------------- Reinvest#1 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
   
-      //   userInfoBefore = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   // PancakeWorker receives 0.151999999999007550 cake as a reward
-      //   // Eve got 10% of 0.151999999999007550 cake = 0.01 * 0.151999999999007550 = 0.001519999999990075 bounty
-      //   // with previous received cake reward, it will be  0.001519999999990075 + 0.001519999999990075 =~ 0.003039999999988162 CAKE
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.003039999999988162').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
-      //   // Remaining PancakeWorker reward = 0.151999999999007550 - 0.001519999999990075 = 0.150479999999200233 (~90% reward)
-      //   // Convert 0.150479999999200233 cake to 0.053430713396006806 BTOKEN
-      //   // Convert NATIVE to 0.001706268418962981 LP token and stake
-      //   // accumulated LP of the worker will be 1.2433369408841453 + 0.001706268418962981 = 1.2450432093031083 LP
-      //   userInfoAfter = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   expect(userInfoAfter.amount.sub(userInfoBefore.amount)).to.eq(parseEther('0.001706268418962981'))
+        userInfoBefore = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
+        // PancakeWorker receives 0.151999999999007550 cake as a reward
+        // Eve got 10% of 0.151999999999007550 cake = 0.01 * 0.151999999999007550 = 0.001519999999990075 bounty
+        // with previous received cake reward, it will be  0.001519999999990075 + 0.001519999999990075 =~ 0.003039999999988162 CAKE
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.003039999999988162').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
+        // Remaining PancakeWorker reward = 0.151999999999007550 - 0.001519999999990075 = 0.150479999999200233 (~90% reward)
+        // Convert 0.150479999999200233 cake to 0.053430713396006806 BTOKEN
+        // Convert NATIVE to 0.001706268418962981 LP token and stake
+        // accumulated LP of the worker will be 1.2433369408841453 + 0.001706268418962981 = 1.2450432093031083 LP
+        userInfoAfter = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        expect(userInfoAfter.amount.sub(userInfoBefore.amount)).to.eq(parseEther('0.001706268418962981'))
   
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(userInfoAfter.amount).to.be.bignumber.gt(userInfoBefore.amount);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(userInfoAfter.amount).to.be.bignumber.gt(userInfoBefore.amount);
   
-      //   // Check Bob position info
-      //   await pancakeswapV2Worker.health('1');
-      //   let [bobHealth, bobDebtToShare] = await vault.positionInfo('1');
-      //   expect(bobHealth).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10').toString(),
-      //     bobDebtToShare.toString(),
-      //   );
+        // Check Bob position info
+        await pancakeswapV2Worker.health('1');
+        let [bobHealth, bobDebtToShare] = await vault.positionInfo('1');
+        expect(bobHealth).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10').toString(),
+          bobDebtToShare.toString(),
+        );
   
-      //   // Check Alice position info
-      //   await pancakeswapV2Worker.health('2');
-      //   let [aliceHealth, aliceDebtToShare] = await vault.positionInfo('2');
-      //   expect(aliceHealth).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('2').toString(),
-      //     aliceDebtToShare.toString(),
-      //   );
+        // Check Alice position info
+        await pancakeswapV2Worker.health('2');
+        let [aliceHealth, aliceDebtToShare] = await vault.positionInfo('2');
+        expect(aliceHealth).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('2').toString(),
+          aliceDebtToShare.toString(),
+        );
   
-      //   // ---------------- Reinvest#2 -------------------
-      //   // Wait for 1 day and someone calls reinvest
-      //   await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
-      //   userInfoBefore = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await pancakeswapV2WorkerAsEve.reinvest();
-      //   // PancakeWorker receives 0.151999999999007550 cake as a reward
-      //   // Eve got 10% of 0.151999999999007550 cake = 0.01 * 0.151999999999007550 = 0.001519999999990075 bounty
-      //   // with previous received cake reward, it will be  0.003039999999988162 + 0.001519999999990075 =~ 0.004559999999987660
-      //   // eve should earn cake as a reward for reinvest
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('0.004559999999987660').toString(),
-      //     (await cake.balanceOf(await eve.getAddress())).toString(),
-      //   );
+        // ---------------- Reinvest#2 -------------------
+        // Wait for 1 day and someone calls reinvest
+        await TimeHelpers.increase(TimeHelpers.duration.days(ethers.BigNumber.from('1')));
+        userInfoBefore = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await pancakeswapV2WorkerAsEve.reinvest();
+        // PancakeWorker receives 0.151999999999007550 cake as a reward
+        // Eve got 10% of 0.151999999999007550 cake = 0.01 * 0.151999999999007550 = 0.001519999999990075 bounty
+        // with previous received cake reward, it will be  0.003039999999988162 + 0.001519999999990075 =~ 0.004559999999987660
+        // eve should earn cake as a reward for reinvest
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('0.004559999999987660').toString(),
+          (await cake.balanceOf(await eve.getAddress())).toString(),
+        );
 
-      //   // Remaining PancakeWorker reward = 0.151999999999007550 - 0.001519999999990075 = 0.150479999999200233 (~90% reward)
-      //   // Convert 0.150479999999200233 cake to 0.053430713396006806 BTOKEN
-      //   // Convert NATIVE to 0.000682143588031014 LP token and stake
-      //   // accumulated LP of the worker will be 1.2450432093031083 + 0.000682143588031014 = 1.2457253528911394 LP
-      //   userInfoAfter = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // LP tokens of worker should be inceased from reinvestment
-      //   expect(userInfoAfter.amount).to.be.bignumber.gt(userInfoBefore.amount);
-      //   expect(userInfoAfter.amount.sub(userInfoBefore.amount)).to.eq(parseEther('0.000682143588031014'))
+        // Remaining PancakeWorker reward = 0.151999999999007550 - 0.001519999999990075 = 0.150479999999200233 (~90% reward)
+        // Convert 0.150479999999200233 cake to 0.053430713396006806 BTOKEN
+        // Convert NATIVE to 0.000682143588031014 LP token and stake
+        // accumulated LP of the worker will be 1.2450432093031083 + 0.000682143588031014 = 1.2457253528911394 LP
+        userInfoAfter = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // LP tokens of worker should be inceased from reinvestment
+        expect(userInfoAfter.amount).to.be.bignumber.gt(userInfoBefore.amount);
+        expect(userInfoAfter.amount.sub(userInfoBefore.amount)).to.eq(parseEther('0.000682143588031014'))
   
-      //   // Check Bob position info
-      //   ;[bobHealth, bobDebtToShare] = await vault.positionInfo('1');
-      //   expect(bobHealth).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('10').toString(),
-      //     bobDebtToShare.toString(),
-      //   );
+        // Check Bob position info
+        ;[bobHealth, bobDebtToShare] = await vault.positionInfo('1');
+        expect(bobHealth).to.be.bignumber.gt(ethers.utils.parseEther('20')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('10').toString(),
+          bobDebtToShare.toString(),
+        );
   
-      //   // Check Alice position info
-      //   [aliceHealth, aliceDebtToShare] = await vault.positionInfo('2');
-      //   expect(aliceHealth).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
-      //   AssertHelpers.assertAlmostEqual(
-      //     ethers.utils.parseEther('2').toString(),
-      //     aliceDebtToShare.toString(),
-      //   );
+        // Check Alice position info
+        [aliceHealth, aliceDebtToShare] = await vault.positionInfo('2');
+        expect(aliceHealth).to.be.bignumber.gt(ethers.utils.parseEther('3')); // Get Reward and increase health
+        AssertHelpers.assertAlmostEqual(
+          ethers.utils.parseEther('2').toString(),
+          aliceDebtToShare.toString(),
+        );
   
-      //   const bobBefore = await baseToken.balanceOf(await bob.getAddress());
-      //   const [bobHealthBefore, ] = await vault.positionInfo('1');
-      //   const lpUnderBobPosition = await pancakeswapV2Worker.shareToBalance(await pancakeswapV2Worker.shares(1));
-      //   userInfoBefore = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // Bob think he made enough. He now wants to close position partially.
-      //   // After calling `work()`, the `_reinvest()` is invoked
-      //   // since 1 blocks have passed since approve and work now reward will be 0.076 * 1 =~ 0.075999999998831803 ~   CAKE
-      //   // reward without bounty will be 0.075999999998831803 - 0.000759999999988318 =~ 0.0752399999988435 CAKE
-      //   // 0.0752399999988435 CAKE can be converted into: 
-      //   // (0.0752399999988435 * 0.9975 * 0.181910827281197007) / (0.551439999997349147 + 0.0752399999988435 * 0.9975) = 0.021792385851914001 WBNB
-      //   // 0.021792385851914001 WBNB can be converted into (0.021792385851914001 * 0.9975 * 0.550713681895118383) / (1.818089172718802993 + 0.021792385851914001 * 0.9975) = 0.006506786307732169 BTOKEN
-      //   // based on optimal swap formula, 0.006506786307732169 BTOKEN needs to swap 0.003257248283727063 BTOKEN
-      //   // new reserve after swap will be 24.452543566388608680 0.099986712604207391
-      //   // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 0.003249538024005106 BTOKEN - 0.000013287395792609 FTOKEN
-      //   // new reserve after adding liquidity receiving from `_reinvest()` is 24.455793104412613786 BTOKEN - 0.100000000000000000 FTOKEN
-      //   // more LP amount after executing add strategy will be 0.000207570473714694 LP
-      //   // accumulated LP of the worker will be 1.2457253528911394 + 0.000207570473714694 = 1.2459329233648542 LP
+        const bobBefore = await baseToken.balanceOf(await bob.getAddress());
+        const [bobHealthBefore, ] = await vault.positionInfo('1');
+        const lpUnderBobPosition = await pancakeswapV2Worker.shareToBalance(await pancakeswapV2Worker.shares(1));
+        userInfoBefore = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // Bob think he made enough. He now wants to close position partially.
+        // After calling `work()`, the `_reinvest()` is invoked
+        // since 1 blocks have passed since approve and work now reward will be 0.076 * 1 =~ 0.075999999998831803 ~   CAKE
+        // reward without bounty will be 0.075999999998831803 - 0.000759999999988318 =~ 0.0752399999988435 CAKE
+        // 0.0752399999988435 CAKE can be converted into: 
+        // (0.0752399999988435 * 0.9975 * 0.181910827281197007) / (0.551439999997349147 + 0.0752399999988435 * 0.9975) = 0.021792385851914001 WBNB
+        // 0.021792385851914001 WBNB can be converted into (0.021792385851914001 * 0.9975 * 0.550713681895118383) / (1.818089172718802993 + 0.021792385851914001 * 0.9975) = 0.006506786307732169 BTOKEN
+        // based on optimal swap formula, 0.006506786307732169 BTOKEN needs to swap 0.003257248283727063 BTOKEN
+        // new reserve after swap will be 24.452543566388608680 0.099986712604207391
+        // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 0.003249538024005106 BTOKEN - 0.000013287395792609 FTOKEN
+        // new reserve after adding liquidity receiving from `_reinvest()` is 24.455793104412613786 BTOKEN - 0.100000000000000000 FTOKEN
+        // more LP amount after executing add strategy will be 0.000207570473714694 LP
+        // accumulated LP of the worker will be 1.2457253528911394 + 0.000207570473714694 = 1.2459329233648542 LP
         
-      //   // bob close 50% of his position, thus he will close 1.131492691639043045 * (1.2457253528911394 /  (1.131492691639043045 (bob's share) + 0.099009277677144773 (alice's share))) =~ 1.146525881438009825 / 2 = 0.573262940719004912 LP
-      //   // 0.573262940719004912 LP will be converted into 8.974492808547204961 BTOKEN - 0.036696797238311265 FTOKEN
-      //   // 0.036696797238311265 FTOKEN will be converted into (0.036696797238311265 * 0.9975 * 15.481300295865408825) / (0.063303202761688735 + 0.036696797238311265 * 0.9975) = 5.672142262341941975 BTOKEN
-      //   // thus, Bob will receive 5.672142262341941975 + 8.974492808547204961 = 14.646635070889146936 BTOKEN
-      //   await vaultAsBob.work(
-      //     1,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     ethers.utils.parseEther('5'),
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [partialCloseStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256', 'uint256'],
-      //         [lpUnderBobPosition.div(2), '0'])
-      //       ]
-      //     )
-      //   );
-      //   const bobAfter = await baseToken.balanceOf(await bob.getAddress());
-      //   // After Bob liquidate half of his position which worth
-      //   // 14.646635070889146936 BTOKEN (price impact+trading fee included)
-      //   // Bob returns 5 BTOKEN to payback the debt hence; He should be
-      //   // 14.646635070889146936 - 5 = 9.646635070889147 BTOKEN richer
-      //   AssertHelpers.assertAlmostEqual(
-      //     bobAfter.toString(),
-      //     bobBefore.add(ethers.utils.parseEther('9.646635070889147')).toString(),
-      //   );
-      //   // Check Bob position info
-      //   [bobHealth, bobDebtToShare] = await vault.positionInfo('1');
-      //   // Bob's health after partial close position must be 50% less than before
-      //   // due to he exit half of lp under his position
-      //   expect(bobHealth).to.be.bignumber.lt(bobHealthBefore.div(2));
-      //   // Bob's debt should be left only 5 BTOKEN due he said he wants to return at max 5 BTOKEN
-      //   expect(bobDebtToShare).to.be.bignumber.eq(ethers.utils.parseEther('5'));
-      //   // Check LP deposited by Worker on MasterChef
-      //   userInfoAfter = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // LP tokens + 0.000207570473714694 LP from reinvest of worker should be decreased by lpUnderBobPosition/2
-      //   // due to Bob execute StrategyClosePartialLiquidate
-      //   expect(userInfoAfter.amount).to.be.bignumber.eq(userInfoBefore.amount.add(parseEther('0.000207570473714694')).sub(lpUnderBobPosition.div(2)));
-      // }).timeout(50000);
+        // bob close 50% of his position, thus he will close 1.131492691639043045 * (1.2457253528911394 /  (1.131492691639043045 (bob's share) + 0.099009277677144773 (alice's share))) =~ 1.146525881438009825 / 2 = 0.573262940719004912 LP
+        // 0.573262940719004912 LP will be converted into 8.974492808547204961 BTOKEN - 0.036696797238311265 FTOKEN
+        // 0.036696797238311265 FTOKEN will be converted into (0.036696797238311265 * 0.9975 * 15.481300295865408825) / (0.063303202761688735 + 0.036696797238311265 * 0.9975) = 5.672142262341941975 BTOKEN
+        // thus, Bob will receive 5.672142262341941975 + 8.974492808547204961 = 14.646635070889146936 BTOKEN
+        await vaultAsBob.work(
+          1,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          ethers.utils.parseEther('5'),
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [partialCloseStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256', 'uint256'],
+              [lpUnderBobPosition.div(2), '0'])
+            ]
+          )
+        );
+        const bobAfter = await baseToken.balanceOf(await bob.getAddress());
+        // After Bob liquidate half of his position which worth
+        // 14.646635070889146936 BTOKEN (price impact+trading fee included)
+        // Bob returns 5 BTOKEN to payback the debt hence; He should be
+        // 14.646635070889146936 - 5 = 9.646635070889147 BTOKEN richer
+        AssertHelpers.assertAlmostEqual(
+          bobAfter.toString(),
+          bobBefore.add(ethers.utils.parseEther('9.646635070889147')).toString(),
+        );
+        // Check Bob position info
+        [bobHealth, bobDebtToShare] = await vault.positionInfo('1');
+        // Bob's health after partial close position must be 50% less than before
+        // due to he exit half of lp under his position
+        expect(bobHealth).to.be.bignumber.lt(bobHealthBefore.div(2));
+        // Bob's debt should be left only 5 BTOKEN due he said he wants to return at max 5 BTOKEN
+        expect(bobDebtToShare).to.be.bignumber.eq(ethers.utils.parseEther('5'));
+        // Check LP deposited by Worker on MasterChef
+        userInfoAfter = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // LP tokens + 0.000207570473714694 LP from reinvest of worker should be decreased by lpUnderBobPosition/2
+        // due to Bob execute StrategyClosePartialLiquidate
+        expect(userInfoAfter.amount).to.be.bignumber.eq(userInfoBefore.amount.add(parseEther('0.000207570473714694')).sub(lpUnderBobPosition.div(2)));
+      }).timeout(50000);
   
-      // it('should partially close position successfully, when maxReturn > liquidated amount and liquidated amount > debt', async () => {
-      //   // Set Bank's debt interests to 0% per year
-      //   await simpleVaultConfig.setParams(
-      //     ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
-      //     '0', // 0% per year
-      //     '1000', // 10% reserve pool
-      //     '1000', // 10% Kill prize
-      //     wbnb.address,
-      //     wNativeRelayer.address,
-      //     fairLaunch.address,
-      //   );
+      it('should partially close position successfully, when maxReturn > liquidated amount and liquidated amount > debt', async () => {
+        // Set Bank's debt interests to 0% per year
+        await simpleVaultConfig.setParams(
+          ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
+          '0', // 0% per year
+          '1000', // 10% reserve pool
+          '1000', // 10% Kill prize
+          wbnb.address,
+          wNativeRelayer.address,
+          fairLaunch.address,
+        );
   
-      //   // Bob deposits 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('10'));
+        // Bob deposits 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('10'));
   
-      //   // Position#1: Bob borrows 10 BTOKEN loan and supply another 10 BToken
-      //   // Thus, Bob's position value will be worth 20 BTOKEN 
-      //   // After calling `work()` 
-      //   // 20 BTOKEN needs to swap 3.587061715703192586 BTOKEN to FTOKEN
-      //   // new reserve after swap will be 4.587061715703192586 0.021843151027158060
-      //   // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 16.412938284296807414 BTOKEN - 0.078156848972841940 FTOKEN
-      //   // new reserve after adding liquidity 21.000000000000000000 BTOKEN - 0.100000000000000000 FTOKEN
-      //   // lp amount from adding liquidity will be 1.131492691639043045 LP
-      //   let [workerLPBefore, ] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Position#1: Bob borrows 10 BTOKEN loan and supply another 10 BToken
+        // Thus, Bob's position value will be worth 20 BTOKEN 
+        // After calling `work()` 
+        // 20 BTOKEN needs to swap 3.587061715703192586 BTOKEN to FTOKEN
+        // new reserve after swap will be 4.587061715703192586 0.021843151027158060
+        // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 16.412938284296807414 BTOKEN - 0.078156848972841940 FTOKEN
+        // new reserve after adding liquidity 21.000000000000000000 BTOKEN - 0.100000000000000000 FTOKEN
+        // lp amount from adding liquidity will be 1.131492691639043045 LP
+        let [workerLPBefore, ] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
 
-      //   let [workerLPAfter, ] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   expect(workerLPAfter.sub(workerLPBefore)).to.eq(parseEther('1.131492691639043045'))
+        let [workerLPAfter, ] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        expect(workerLPAfter.sub(workerLPBefore)).to.eq(parseEther('1.131492691639043045'))
 
-      //   // Bob think he made enough. He now wants to close position partially.
-      //   // He close 50% of his position and return all debt
-      //   const bobBefore = await baseToken.balanceOf(await bob.getAddress());
-      //   const [bobHealthBefore, ] = await vault.positionInfo('1');
-      //   const lpUnderBobPosition = await pancakeswapV2Worker.shareToBalance(await pancakeswapV2Worker.shares(1));
-      //   [workerLPBefore,] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // Bob think he made enough. He now wants to close position partially.
+        // He close 50% of his position and return all debt
+        const bobBefore = await baseToken.balanceOf(await bob.getAddress());
+        const [bobHealthBefore, ] = await vault.positionInfo('1');
+        const lpUnderBobPosition = await pancakeswapV2Worker.shareToBalance(await pancakeswapV2Worker.shares(1));
+        [workerLPBefore,] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
   
-      //   // Bob think he made enough. He now wants to close position partially.
-      //   // After calling `work()`, the `_reinvest()` is invoked
-      //   // since 1 blocks have passed since approve and work now reward will be 0.076 * 1 =~ 0.075999999998831803 ~   CAKE
-      //   // reward without bounty will be 0.075999999998831803 - 0.000759999999988318 =~ 0.0752399999988435 CAKE
-      //   // 0.0752399999988435 CAKE can be converted into: 
-      //   // (0.0752399999988435 * 0.9975 * 1) / (0.1 + 0.0752399999988435 * 0.9975) = 0.428740847712892766 WBNB
-      //   // 0.428740847712892766 WBNB can be converted into (0.428740847712892766 * 0.9975 * 1) / (1 + 0.428740847712892766 * 0.9975) = 0.299557528330150526 BTOKEN
-      //   // based on optimal swap formula, 0.299557528330150526 BTOKEN needs to swap 0.149435199790075736 BTOKEN
-      //   // new reserve after swap will be 21.149435199790075736 BTOKEN - 0.099295185694161018 FTOKEN
-      //   // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 0.150122328540074790 BTOKEN - 0.000704814305838982 FTOKEN
-      //   // new reserve after adding liquidity receiving from `_reinvest()` is 21.299557528330150526 BTOKEN - 0.100000000000000000 FTOKEN
-      //   // more LP amount after executing add strategy will be 0.010276168801924356 LP
-      //   // accumulated LP of the worker will be 1.131492691639043045 + 0.010276168801924356 = 1.1417688604409675 LP
+        // Bob think he made enough. He now wants to close position partially.
+        // After calling `work()`, the `_reinvest()` is invoked
+        // since 1 blocks have passed since approve and work now reward will be 0.076 * 1 =~ 0.075999999998831803 ~   CAKE
+        // reward without bounty will be 0.075999999998831803 - 0.000759999999988318 =~ 0.0752399999988435 CAKE
+        // 0.0752399999988435 CAKE can be converted into: 
+        // (0.0752399999988435 * 0.9975 * 1) / (0.1 + 0.0752399999988435 * 0.9975) = 0.428740847712892766 WBNB
+        // 0.428740847712892766 WBNB can be converted into (0.428740847712892766 * 0.9975 * 1) / (1 + 0.428740847712892766 * 0.9975) = 0.299557528330150526 BTOKEN
+        // based on optimal swap formula, 0.299557528330150526 BTOKEN needs to swap 0.149435199790075736 BTOKEN
+        // new reserve after swap will be 21.149435199790075736 BTOKEN - 0.099295185694161018 FTOKEN
+        // based on optimal swap formula, BTOKEN-FTOKEN to be added into the LP will be 0.150122328540074790 BTOKEN - 0.000704814305838982 FTOKEN
+        // new reserve after adding liquidity receiving from `_reinvest()` is 21.299557528330150526 BTOKEN - 0.100000000000000000 FTOKEN
+        // more LP amount after executing add strategy will be 0.010276168801924356 LP
+        // accumulated LP of the worker will be 1.131492691639043045 + 0.010276168801924356 = 1.1417688604409675 LP
         
-      //   // bob close 50% of his position, thus he will close 1.131492691639043045 * (1.131492691639043045 / (1.131492691639043045)) =~ 1.131492691639043045 / 2 = 0.5657463458195215 LP
-      //   // 0.5657463458195215 LP will be converted into 8.264866063854500749 BTOKEN - 0.038802994160144191 FTOKEN
-      //   // 0.038802994160144191 FTOKEN will be converted into (0.038802994160144191 * 0.9975 * 13.034691464475649777) / (0.061197005839855809 + 0.038802994160144191 * 0.9975) = 5.050104921127982573 BTOKEN
-      //   // thus, Bob will receive 8.264866063854500749 + 5.050104921127982573 = 13.314970984982483322 BTOKEN
-      //   await vaultAsBob.work(
-      //     1,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     ethers.utils.parseEther('5000000000'),
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [partialCloseStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256', 'uint256'],
-      //         [lpUnderBobPosition.div(2), '0'])
-      //       ]
-      //     )
-      //   );
-      //   const bobAfter = await baseToken.balanceOf(await bob.getAddress());
+        // bob close 50% of his position, thus he will close 1.131492691639043045 * (1.131492691639043045 / (1.131492691639043045)) =~ 1.131492691639043045 / 2 = 0.5657463458195215 LP
+        // 0.5657463458195215 LP will be converted into 8.264866063854500749 BTOKEN - 0.038802994160144191 FTOKEN
+        // 0.038802994160144191 FTOKEN will be converted into (0.038802994160144191 * 0.9975 * 13.034691464475649777) / (0.061197005839855809 + 0.038802994160144191 * 0.9975) = 5.050104921127982573 BTOKEN
+        // thus, Bob will receive 8.264866063854500749 + 5.050104921127982573 = 13.314970984982483322 BTOKEN
+        await vaultAsBob.work(
+          1,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          ethers.utils.parseEther('5000000000'),
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [partialCloseStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256', 'uint256'],
+              [lpUnderBobPosition.div(2), '0'])
+            ]
+          )
+        );
+        const bobAfter = await baseToken.balanceOf(await bob.getAddress());
   
-      //   // After Bob liquidate half of his position which worth
-      //   // 13.314970984982483322 BTOKEN (price impact+trading fee included)
-      //   // Bob wish to return 5,000,000,000 BTOKEN (when maxReturn > debt, return all debt) 
-      //   // The following criteria must be stratified:
-      //   // - Bob should get 13.314970984982483322 - 10 = 3.314970984982483322 BTOKEN back.
-      //   // - Bob's position debt must be 0
-      //   expect(
-      //     bobBefore.add(ethers.utils.parseEther('3.314970984982483322')),
-      //     "Expect BTOKEN in Bob's account after close position to increase by ~3.32 BTOKEN").to.be.bignumber.eq(bobAfter)
-      //   // Check Bob position info
-      //   const [bobHealth, bobDebtVal] = await vault.positionInfo('1');
-      //   // Bob's health after partial close position must be 50% less than before
-      //   // due to he exit half of lp under his position
-      //   expect(bobHealth).to.be.bignumber.lt(bobHealthBefore.div(2));
-      //   // Bob's debt should be 0 BTOKEN due he said he wants to return at max 5,000,000,000 BTOKEN (> debt, return all debt)
-      //   expect(bobDebtVal).to.be.bignumber.eq('0');
-      //   // Check LP deposited by Worker on MasterChef
-      //   [workerLPAfter,] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
-      //   // LP tokens + LP tokens from reinvest of worker should be decreased by lpUnderBobPosition/2
-      //   // due to Bob execute StrategyClosePartialLiquidate
-      //   expect(workerLPAfter).to.be.bignumber.eq(workerLPBefore.add(parseEther('0.010276168801924356')).sub(lpUnderBobPosition.div(2)));
-      // }).timeout(50000);
+        // After Bob liquidate half of his position which worth
+        // 13.314970984982483322 BTOKEN (price impact+trading fee included)
+        // Bob wish to return 5,000,000,000 BTOKEN (when maxReturn > debt, return all debt) 
+        // The following criteria must be stratified:
+        // - Bob should get 13.314970984982483322 - 10 = 3.314970984982483322 BTOKEN back.
+        // - Bob's position debt must be 0
+        expect(
+          bobBefore.add(ethers.utils.parseEther('3.314970984982483322')),
+          "Expect BTOKEN in Bob's account after close position to increase by ~3.32 BTOKEN").to.be.bignumber.eq(bobAfter)
+        // Check Bob position info
+        const [bobHealth, bobDebtVal] = await vault.positionInfo('1');
+        // Bob's health after partial close position must be 50% less than before
+        // due to he exit half of lp under his position
+        expect(bobHealth).to.be.bignumber.lt(bobHealthBefore.div(2));
+        // Bob's debt should be 0 BTOKEN due he said he wants to return at max 5,000,000,000 BTOKEN (> debt, return all debt)
+        expect(bobDebtVal).to.be.bignumber.eq('0');
+        // Check LP deposited by Worker on MasterChef
+        [workerLPAfter,] = await masterChef.userInfo(poolId, pancakeswapV2Worker.address);
+        // LP tokens + LP tokens from reinvest of worker should be decreased by lpUnderBobPosition/2
+        // due to Bob execute StrategyClosePartialLiquidate
+        expect(workerLPAfter).to.be.bignumber.eq(workerLPBefore.add(parseEther('0.010276168801924356')).sub(lpUnderBobPosition.div(2)));
+      }).timeout(50000);
   
-      // it('should revert when partial close position made leverage higher than work factor', async () => {
-      //   // Set Bank's debt interests to 0% per year
-      //   await simpleVaultConfig.setParams(
-      //     ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
-      //     '0', // 0% per year
-      //     '1000', // 10% reserve pool
-      //     '1000', // 10% Kill prize
-      //     wbnb.address,
-      //     wNativeRelayer.address,
-      //     fairLaunch.address,
-      //   );
+      it('should revert when partial close position made leverage higher than work factor', async () => {
+        // Set Bank's debt interests to 0% per year
+        await simpleVaultConfig.setParams(
+          ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
+          '0', // 0% per year
+          '1000', // 10% reserve pool
+          '1000', // 10% Kill prize
+          wbnb.address,
+          wNativeRelayer.address,
+          fairLaunch.address,
+        );
   
-      //   // Bob deposits 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('10'));
+        // Bob deposits 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('10'));
   
-      //   // Position#1: Bob borrows 10 BTOKEN loan
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return BTOKEN to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Position#1: Bob borrows 10 BTOKEN loan
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
   
-      //   // Bob think he made enough. He now wants to close position partially.
-      //   // He liquidate all of his position but not payback the debt.
-      //   const lpUnderBobPosition = await pancakeswapV2Worker.shareToBalance(await pancakeswapV2Worker.shares(1));
-      //   // Bob closes position with maxReturn 5,000,000,000 and liquidate half of his position
-      //   // Expect that Bob will not be able to close his position as he liquidate all underlying assets but not paydebt
-      //   // which made his position debt ratio higher than allow work factor
-      //   await expect(vaultAsBob.work(
-      //     1,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     '0',
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [partialCloseStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256', 'uint256'],
-      //         [lpUnderBobPosition, '0'])
-      //       ]
-      //     )
-      //   )).revertedWith("Vault::work:: bad work factor");
-      // }).timeout(50000);
+        // Bob think he made enough. He now wants to close position partially.
+        // He liquidate all of his position but not payback the debt.
+        const lpUnderBobPosition = await pancakeswapV2Worker.shareToBalance(await pancakeswapV2Worker.shares(1));
+        // Bob closes position with maxReturn 5,000,000,000 and liquidate half of his position
+        // Expect that Bob will not be able to close his position as he liquidate all underlying assets but not paydebt
+        // which made his position debt ratio higher than allow work factor
+        await expect(vaultAsBob.work(
+          1,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          '0',
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [partialCloseStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256', 'uint256'],
+              [lpUnderBobPosition, '0'])
+            ]
+          )
+        )).revertedWith("Vault::work:: bad work factor");
+      }).timeout(50000);
   
-      // it('should not allow to partially close position, when returnLpAmount > LpUnderPosition', async () => {
-      //   // Set Bank's debt interests to 0% per year
-      //   await simpleVaultConfig.setParams(
-      //     ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
-      //     '0', // 0% per year
-      //     '1000', // 10% reserve pool
-      //     '1000', // 10% Kill prize
-      //     wbnb.address,
-      //     wNativeRelayer.address,
-      //     fairLaunch.address,
-      //   );
+      it('should not allow to partially close position, when returnLpAmount > LpUnderPosition', async () => {
+        // Set Bank's debt interests to 0% per year
+        await simpleVaultConfig.setParams(
+          ethers.utils.parseEther('1'), // 1 BTOKEN min debt size,
+          '0', // 0% per year
+          '1000', // 10% reserve pool
+          '1000', // 10% Kill prize
+          wbnb.address,
+          wNativeRelayer.address,
+          fairLaunch.address,
+        );
   
-      //   // Bob deposits 10 BTOKEN
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
-      //   await vaultAsBob.deposit(ethers.utils.parseEther('10'));
+        // Bob deposits 10 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'));
+        await vaultAsBob.deposit(ethers.utils.parseEther('10'));
   
-      //   // Position#1: Bob borrows 10 BTOKEN loan
-      //   await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
-      //   await vaultAsBob.work(
-      //     0,
-      //     pancakeswapV2Worker.address,
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.parseEther('10'),
-      //     '0', // max return = 0, don't return NATIVE to the debt
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [addStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256'],
-      //         ['0'])
-      //       ]
-      //     ),
-      //   );
+        // Position#1: Bob borrows 10 BTOKEN loan
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther('10'))
+        await vaultAsBob.work(
+          0,
+          pancakeswapV2Worker.address,
+          ethers.utils.parseEther('10'),
+          ethers.utils.parseEther('10'),
+          '0', // max return = 0, don't return NATIVE to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256'],
+              ['0'])
+            ]
+          ),
+        );
   
-      //   // Bob think he made enough. He now wants to close position partially. However, his input is invalid.
-      //   // He put returnLpAmount > Lp that is under his position
-      //   const lpUnderBobPosition = await pancakeswapV2Worker.shareToBalance(await pancakeswapV2Worker.shares(1));
-      //   // Transaction should be revert due to Bob is asking contract to liquidate Lp amount > Lp that is under his position
-      //   await expect(vaultAsBob.work(
-      //     1,
-      //     pancakeswapV2Worker.address,
-      //     '0',
-      //     '0',
-      //     ethers.utils.parseEther('10'),
-      //     ethers.utils.defaultAbiCoder.encode(
-      //       ['address', 'bytes'],
-      //       [partialCloseStrat.address, ethers.utils.defaultAbiCoder.encode(
-      //         ['uint256', 'uint256'],
-      //         [lpUnderBobPosition.mul(2), '0'])
-      //       ]
-      //     )
-      //   )).to.be.revertedWith('StrategyPartialCloseLiquidate::execute:: insufficient LP amount recevied from worker');
-      // }).timeout(50000);
+        // Bob think he made enough. He now wants to close position partially. However, his input is invalid.
+        // He put returnLpAmount > Lp that is under his position
+        const lpUnderBobPosition = await pancakeswapV2Worker.shareToBalance(await pancakeswapV2Worker.shares(1));
+        // Transaction should be revert due to Bob is asking contract to liquidate Lp amount > Lp that is under his position
+        await expect(vaultAsBob.work(
+          1,
+          pancakeswapV2Worker.address,
+          '0',
+          '0',
+          ethers.utils.parseEther('10'),
+          ethers.utils.defaultAbiCoder.encode(
+            ['address', 'bytes'],
+            [partialCloseStrat.address, ethers.utils.defaultAbiCoder.encode(
+              ['uint256', 'uint256'],
+              [lpUnderBobPosition.mul(2), '0'])
+            ]
+          )
+        )).to.be.revertedWith('StrategyPartialCloseLiquidate::execute:: insufficient LP amount recevied from worker');
+      }).timeout(50000);
 
       context("When the treasury Account and treasury bounty bps haven't been set", async () => {
         it('should not auto reinvest', async () => {


### PR DESCRIPTION
## Description
Change reinvest threshold logic to make `reinvest()` always reinvest regardless of the `pendingXXX()`.

## Why?
To avoid indefinitely pending rewards that won't get reinvested.
