### PR TITLE
[main][chore] Resolved partial close strategies issues raised by audit

### DIFF
--- a/contracts/6/protocol/strategies/pancakeswap/StrategyAddBaseTokenOnly.sol
+++ b/contracts/6/protocol/strategies/pancakeswap/StrategyAddBaseTokenOnly.sol
@@ -33,7 +33,7 @@ contract StrategyAddBaseTokenOnly is ReentrancyGuardUpgradeSafe, IStrategy {
   IPancakeRouter02 public router;
 
   /// @dev Create a new add Token only strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) external initializer {
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
 
@@ -43,17 +43,13 @@ contract StrategyAddBaseTokenOnly is ReentrancyGuardUpgradeSafe, IStrategy {
 
   /// @dev Execute worker strategy. Take BaseToken. Return LP tokens.
   /// @param data Extra calldata information passed along to this strategy.
-  function execute(address /* user */, uint256 /* debt */, bytes calldata data)
-    external
-    override
-    nonReentrant
-  {
+  function execute(
+    address, /* user */
+    uint256, /* debt */
+    bytes calldata data
+  ) external override nonReentrant {
     // 1. Find out what farming token we are dealing with and min additional LP tokens.
-    (
-      address baseToken,
-      address farmingToken,
-      uint256 minLPAmount
-    ) = abi.decode(data, (address, address, uint256));
+    (address baseToken, address farmingToken, uint256 minLPAmount) = abi.decode(data, (address, address, uint256));
     IPancakePair lpToken = IPancakePair(factory.getPair(farmingToken, baseToken));
     // 2. Approve router to do their stuffs
     farmingToken.safeApprove(address(router), uint256(-1));
@@ -73,11 +69,22 @@ contract StrategyAddBaseTokenOnly is ReentrancyGuardUpgradeSafe, IStrategy {
     path[1] = farmingToken;
     router.swapExactTokensForTokens(aIn, 0, path, address(this), now);
     // 5. Mint more LP tokens and return all LP tokens to the sender.
-    (,, uint256 moreLPAmount) = router.addLiquidity(
-      baseToken, farmingToken, baseToken.myBalance(), farmingToken.myBalance(), 0, 0, address(this), now
-    );
+    (, , uint256 moreLPAmount) =
+      router.addLiquidity(
+        baseToken,
+        farmingToken,
+        baseToken.myBalance(),
+        farmingToken.myBalance(),
+        0,
+        0,
+        address(this),
+        now
+      );
     require(moreLPAmount >= minLPAmount, "StrategyAddBaseTokenOnly::execute:: insufficient LP tokens received");
-    require(lpToken.transfer(msg.sender, lpToken.balanceOf(address(this))), "StrategyAddBaseTokenOnly::execute:: failed to transfer LP token to msg.sender");
+    require(
+      lpToken.transfer(msg.sender, lpToken.balanceOf(address(this))),
+      "StrategyAddBaseTokenOnly::execute:: failed to transfer LP token to msg.sender"
+    );
     // 6. Reset approval for safety reason
     baseToken.safeApprove(address(router), 0);
     farmingToken.safeApprove(address(router), 0);

--- a/contracts/6/protocol/strategies/pancakeswap/StrategyAddTwoSidesOptimal.sol
+++ b/contracts/6/protocol/strategies/pancakeswap/StrategyAddTwoSidesOptimal.sol
@@ -36,7 +36,7 @@ contract StrategyAddTwoSidesOptimal is ReentrancyGuardUpgradeSafe, IStrategy {
   IVault public vault;
 
   /// @dev Create a new add two-side optimal strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router, IVault _vault) external initializer {
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
 
@@ -94,15 +94,15 @@ contract StrategyAddTwoSidesOptimal is ReentrancyGuardUpgradeSafe, IStrategy {
 
   /// @dev Execute worker strategy. Take BaseToken + FarmingToken. Return LP tokens.
   /// @param data Extra calldata information passed along to this strategy.
-  function execute(address /* user */, uint256, /* debt */ bytes calldata data) external override nonReentrant
-  {
+  function execute(
+    address, /* user */
+    uint256,
+    /* debt */
+    bytes calldata data
+  ) external override nonReentrant {
     // 1. Find out what farming token we are dealing with.
-    (
-        address baseToken,
-        address farmingToken,
-        uint256 farmingTokenAmount,
-        uint256 minLPAmount
-    ) = abi.decode(data, (address, address, uint256, uint256));
+    (address baseToken, address farmingToken, uint256 farmingTokenAmount, uint256 minLPAmount) =
+      abi.decode(data, (address, address, uint256, uint256));
     IPancakePair lpToken = IPancakePair(factory.getPair(farmingToken, baseToken));
     // 2. Approve router to do their stuffs
     baseToken.safeApprove(address(router), uint256(-1));
@@ -115,7 +115,12 @@ contract StrategyAddTwoSidesOptimal is ReentrancyGuardUpgradeSafe, IStrategy {
     {
       (uint256 r0, uint256 r1, ) = lpToken.getReserves();
       (uint256 baseTokenReserve, uint256 farmingTokenReserve) = lpToken.token0() == baseToken ? (r0, r1) : (r1, r0);
-      (swapAmt, isReversed) = optimalDeposit(baseTokenBalance, farmingToken.myBalance(), baseTokenReserve, farmingTokenReserve);
+      (swapAmt, isReversed) = optimalDeposit(
+        baseTokenBalance,
+        farmingToken.myBalance(),
+        baseTokenReserve,
+        farmingTokenReserve
+      );
     }
     // 4. Convert between BaseToken and farming tokens
     address[] memory path = new address[](2);
@@ -123,11 +128,22 @@ contract StrategyAddTwoSidesOptimal is ReentrancyGuardUpgradeSafe, IStrategy {
     // 5. Swap according to path
     if (swapAmt > 0) router.swapExactTokensForTokens(swapAmt, 0, path, address(this), now);
     // 6. Mint more LP tokens and return all LP tokens to the sender.
-    (,, uint256 moreLPAmount) = router.addLiquidity(
-      baseToken, farmingToken, baseToken.myBalance(), farmingToken.myBalance(), 0, 0, address(this), now
-    );
+    (, , uint256 moreLPAmount) =
+      router.addLiquidity(
+        baseToken,
+        farmingToken,
+        baseToken.myBalance(),
+        farmingToken.myBalance(),
+        0,
+        0,
+        address(this),
+        now
+      );
     require(moreLPAmount >= minLPAmount, "StrategyAddTwoSidesOptimal::execute:: insufficient LP tokens received");
-    require(lpToken.transfer(msg.sender, lpToken.balanceOf(address(this))), "StrategyAddTwoSidesOptimal::execute:: failed to transfer LP token to msg.sender");
+    require(
+      lpToken.transfer(msg.sender, lpToken.balanceOf(address(this))),
+      "StrategyAddTwoSidesOptimal::execute:: failed to transfer LP token to msg.sender"
+    );
     // 7. Reset approve to 0 for safety reason
     farmingToken.safeApprove(address(router), 0);
     baseToken.safeApprove(address(router), 0);

--- a/contracts/6/protocol/strategies/pancakeswap/StrategyLiquidate.sol
+++ b/contracts/6/protocol/strategies/pancakeswap/StrategyLiquidate.sol
@@ -31,7 +31,7 @@ contract StrategyLiquidate is ReentrancyGuardUpgradeSafe, IStrategy {
   IPancakeRouter02 public router;
 
   /// @dev Create a new liquidate strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) external initializer {
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
 
@@ -41,17 +41,13 @@ contract StrategyLiquidate is ReentrancyGuardUpgradeSafe, IStrategy {
 
   /// @dev Execute worker strategy. Take LP token. Return  BaseToken.
   /// @param data Extra calldata information passed along to this strategy.
-  function execute(address /* user */, uint256 /* debt */, bytes calldata data)
-    external
-    override
-    nonReentrant
-  {
+  function execute(
+    address, /* user */
+    uint256, /* debt */
+    bytes calldata data
+  ) external override nonReentrant {
     // 1. Find out what farming token we are dealing with.
-    (
-      address baseToken,
-      address farmingToken,
-      uint256 minBaseToken
-    ) = abi.decode(data, (address, address, uint256));
+    (address baseToken, address farmingToken, uint256 minBaseToken) = abi.decode(data, (address, address, uint256));
     IPancakePair lpToken = IPancakePair(factory.getPair(farmingToken, baseToken));
     // 2. Approve router to do their stuffs
     require(lpToken.approve(address(router), uint256(-1)), "StrategyLiquidate::execute:: unable to approve LP token");

--- a/contracts/6/protocol/strategies/pancakeswap/StrategyPartialCloseLiquidate.sol
+++ b/contracts/6/protocol/strategies/pancakeswap/StrategyPartialCloseLiquidate.sol
@@ -31,7 +31,7 @@ contract StrategyPartialCloseLiquidate is ReentrancyGuardUpgradeSafe, IStrategy 
   IPancakeRouter02 public router;
 
   /// @dev Create a new liquidate strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) public initializer {
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
 
@@ -41,20 +41,19 @@ contract StrategyPartialCloseLiquidate is ReentrancyGuardUpgradeSafe, IStrategy 
 
   /// @dev Execute worker strategy. Take LP token. Return  BaseToken.
   /// @param data Extra calldata information passed along to this strategy.
-  function execute(address /* user */, uint256 /* debt */, bytes calldata data)
-    external
-    override
-    nonReentrant
-  {
+  function execute(
+    address, /* user */
+    uint256, /* debt */
+    bytes calldata data
+  ) external override nonReentrant {
     // 1. Find out what farming token we are dealing with.
-    (
-      address baseToken,
-      address farmingToken,
-      uint256 returnLpToken,
-      uint256 minBaseToken
-    ) = abi.decode(data, (address, address, uint256, uint256));
+    (address baseToken, address farmingToken, uint256 returnLpToken, uint256 minBaseToken) =
+      abi.decode(data, (address, address, uint256, uint256));
     IPancakePair lpToken = IPancakePair(factory.getPair(farmingToken, baseToken));
-    require(lpToken.balanceOf(address(this)) >= returnLpToken, "StrategyPartialCloseLiquidate::execute:: insufficient LP amount recevied from worker");
+    require(
+      lpToken.balanceOf(address(this)) >= returnLpToken,
+      "StrategyPartialCloseLiquidate::execute:: insufficient LP amount recevied from worker"
+    );
     // 2. Approve router to do their stuffs
     lpToken.approve(address(router), uint256(-1));
     farmingToken.safeApprove(address(router), uint256(-1));

--- a/contracts/6/protocol/strategies/pancakeswap/StrategyWithdrawMinimizeTrading.sol
+++ b/contracts/6/protocol/strategies/pancakeswap/StrategyWithdrawMinimizeTrading.sol
@@ -36,10 +36,14 @@ contract StrategyWithdrawMinimizeTrading is ReentrancyGuardUpgradeSafe, IStrateg
   IWNativeRelayer public wNativeRelayer;
 
   /// @dev Create a new withdraw minimize trading strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   /// @param _wbnb The wrapped BNB token.
   /// @param _wNativeRelayer The relayer to support native transfer
-  function initialize(IPancakeRouter02 _router, IWETH _wbnb, IWNativeRelayer _wNativeRelayer) external initializer {
+  function initialize(
+    IPancakeRouter02 _router,
+    IWETH _wbnb,
+    IWNativeRelayer _wNativeRelayer
+  ) external initializer {
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
 
     factory = IPancakeFactory(_router.factory());
@@ -53,16 +57,19 @@ contract StrategyWithdrawMinimizeTrading is ReentrancyGuardUpgradeSafe, IStrateg
   /// @param user User address to withdraw liquidity.
   /// @param debt Debt amount in WAD of the user.
   /// @param data Extra calldata information passed along to this strategy.
-  function execute(address user, uint256 debt, bytes calldata data) external override nonReentrant {
+  function execute(
+    address user,
+    uint256 debt,
+    bytes calldata data
+  ) external override nonReentrant {
     // 1. Find out what farming token we are dealing with.
-    (
-      address baseToken,
-      address farmingToken,
-      uint256 minFarmingToken
-    ) = abi.decode(data, (address, address, uint256));
+    (address baseToken, address farmingToken, uint256 minFarmingToken) = abi.decode(data, (address, address, uint256));
     IPancakePair lpToken = IPancakePair(factory.getPair(farmingToken, baseToken));
     // 2. Approve router to do their stuffs
-    require(lpToken.approve(address(router), uint256(-1)), "StrategyWithdrawMinimizeTrading::execute:: failed to approve LP token");
+    require(
+      lpToken.approve(address(router), uint256(-1)),
+      "StrategyWithdrawMinimizeTrading::execute:: failed to approve LP token"
+    );
     farmingToken.safeApprove(address(router), uint256(-1));
     // 3. Remove all liquidity back to BaseToken and farming tokens.
     router.removeLiquidity(baseToken, farmingToken, lpToken.balanceOf(address(this)), 0, 0, address(this), now);
@@ -81,7 +88,10 @@ contract StrategyWithdrawMinimizeTrading is ReentrancyGuardUpgradeSafe, IStrateg
     baseToken.safeTransfer(msg.sender, remainingBalance);
     // 6. Return remaining farming tokens to user.
     uint256 remainingFarmingToken = farmingToken.myBalance();
-    require(remainingFarmingToken >= minFarmingToken, "StrategyWithdrawMinimizeTrading::execute:: insufficient farming tokens received");
+    require(
+      remainingFarmingToken >= minFarmingToken,
+      "StrategyWithdrawMinimizeTrading::execute:: insufficient farming tokens received"
+    );
     if (remainingFarmingToken > 0) {
       if (farmingToken == address(wbnb)) {
         SafeToken.safeTransfer(farmingToken, address(wNativeRelayer), remainingFarmingToken);
@@ -92,7 +102,10 @@ contract StrategyWithdrawMinimizeTrading is ReentrancyGuardUpgradeSafe, IStrateg
       }
     }
     // 7. Reset approval for safety reason
-    require(lpToken.approve(address(router), 0), "StrategyWithdrawMinimizeTrading::execute:: unable to reset lp token approval");
+    require(
+      lpToken.approve(address(router), 0),
+      "StrategyWithdrawMinimizeTrading::execute:: unable to reset lp token approval"
+    );
     farmingToken.safeApprove(address(router), 0);
   }
 

--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted-single-asset/PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted-single-asset/PancakeswapV2RestrictedSingleAssetStrategyPartialCloseLiquidate.sol
@@ -19,7 +19,6 @@ import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 
 import "../../apis/pancake/IPancakeRouter02.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakeFactory.sol";
-import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
 import "../../interfaces/IStrategy.sol";
 import "../../interfaces/IVault.sol";

--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted-single-asset/PancakeswapV2RestrictedSingleAssetStrategyPartialCloseWithdrawMinimizeTrading.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted-single-asset/PancakeswapV2RestrictedSingleAssetStrategyPartialCloseWithdrawMinimizeTrading.sol
@@ -19,7 +19,6 @@ import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 
 import "../../apis/pancake/IPancakeRouter02.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakeFactory.sol";
-import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
 import "../../interfaces/IStrategy.sol";
 import "../../interfaces/IWorker02.sol";

--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted-single-asset/PancakeswapV2RestrictedSingleAssetStrategyPartialCloseWithdrawMinimizeTrading.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted-single-asset/PancakeswapV2RestrictedSingleAssetStrategyPartialCloseWithdrawMinimizeTrading.sol
@@ -13,19 +13,20 @@ Alpaca Fin Corporation
 
 pragma solidity 0.6.6;
 
-import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+
+import "../../apis/pancake/IPancakeRouter02.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakeFactory.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
-import "../../apis/pancake/IPancakeRouter02.sol";
 import "../../interfaces/IStrategy.sol";
-import "../../../utils/SafeToken.sol";
-import "../../../utils/AlpacaMath.sol";
 import "../../interfaces/IWorker02.sol";
 import "../../interfaces/IWNativeRelayer.sol";
+
+import "../../../utils/SafeToken.sol";
+import "../../../utils/AlpacaMath.sol";
 
 contract PancakeswapV2RestrictedSingleAssetStrategyPartialCloseWithdrawMinimizeTrading is
   OwnableUpgradeSafe,

--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyAddBaseTokenOnly.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyAddBaseTokenOnly.sol
@@ -34,7 +34,7 @@ contract PancakeswapV2RestrictedStrategyAddBaseTokenOnly is OwnableUpgradeSafe, 
   IPancakeRouter02 public router;
   mapping(address => bool) public okWorkers;
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(
       okWorkers[msg.sender],
@@ -44,7 +44,7 @@ contract PancakeswapV2RestrictedStrategyAddBaseTokenOnly is OwnableUpgradeSafe, 
   }
 
   /// @dev Create a new add Token only strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) external initializer {
     OwnableUpgradeSafe.__Ownable_init();
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();

--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyAddTwosidesOptimal.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyAddTwosidesOptimal.sol
@@ -42,7 +42,7 @@ contract PancakeswapV2RestrictedStrategyAddTwoSidesOptimal is
 
   mapping(address => bool) public okWorkers;
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(
       okWorkers[msg.sender],
@@ -52,7 +52,7 @@ contract PancakeswapV2RestrictedStrategyAddTwoSidesOptimal is
   }
 
   /// @dev Create a new add two-side optimal strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router, IVault _vault) external initializer {
     OwnableUpgradeSafe.__Ownable_init();
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();

--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyLiquidate.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyLiquidate.sol
@@ -33,14 +33,14 @@ contract PancakeswapV2RestrictedStrategyLiquidate is OwnableUpgradeSafe, Reentra
 
   mapping(address => bool) public okWorkers;
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(okWorkers[msg.sender], "PancakeswapV2RestrictedStrategyLiquidate::onlyWhitelistedWorkers:: bad worker");
     _;
   }
 
   /// @dev Create a new liquidate strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) external initializer {
     OwnableUpgradeSafe.__Ownable_init();
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();

--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyPartialCloseLiquidate.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyPartialCloseLiquidate.sol
@@ -13,17 +13,17 @@ Alpaca Fin Corporation
 
 pragma solidity 0.6.6;
 
-import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
+
+import "../../apis/pancake/IPancakeRouter02.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakeFactory.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
-import "../../apis/pancake/IPancakeRouter02.sol";
 import "../../interfaces/IStrategy.sol";
-import "../../../utils/SafeToken.sol";
 import "../../interfaces/IWorker.sol";
+
+import "../../../utils/SafeToken.sol";
 
 contract PancakeswapV2RestrictedStrategyPartialCloseLiquidate is
   OwnableUpgradeSafe,
@@ -43,7 +43,7 @@ contract PancakeswapV2RestrictedStrategyPartialCloseLiquidate is
     uint256 amounToLiquidate
   );
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(
       okWorkers[msg.sender],
@@ -53,7 +53,7 @@ contract PancakeswapV2RestrictedStrategyPartialCloseLiquidate is
   }
 
   /// @dev Create a new liquidate strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) public initializer {
     OwnableUpgradeSafe.__Ownable_init();
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
@@ -95,7 +95,7 @@ contract PancakeswapV2RestrictedStrategyPartialCloseLiquidate is
       "PancakeswapV2RestrictedStrategyPartialCloseLiquidate::execute:: insufficient baseToken received"
     );
     SafeToken.safeTransfer(baseToken, msg.sender, balance);
-    lpToken.transfer(msg.sender, lpToken.balanceOf(address(this)));
+    address(lpToken).safeTransfer(msg.sender, lpToken.balanceOf(address(this)));
     // 6. Reset approve for safety reason
     address(lpToken).safeApprove(address(router), 0);
     farmingToken.safeApprove(address(router), 0);

--- a/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyPartialCloseMinimizeTrading.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2-restricted/PancakeswapV2RestrictedStrategyPartialCloseMinimizeTrading.sol
@@ -13,19 +13,20 @@ Alpaca Fin Corporation
 
 pragma solidity 0.6.6;
 
-import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+
+import "../../apis/pancake/IPancakeRouter02.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakeFactory.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
-import "../../apis/pancake/IPancakeRouter02.sol";
 import "../../interfaces/IStrategy.sol";
 import "../../interfaces/IWETH.sol";
 import "../../interfaces/IWNativeRelayer.sol";
-import "../../../utils/SafeToken.sol";
 import "../../interfaces/IWorker.sol";
+
+import "../../../utils/SafeToken.sol";
 
 contract PancakeswapV2RestrictedStrategyPartialCloseMinimizeTrading is
   OwnableUpgradeSafe,
@@ -49,7 +50,7 @@ contract PancakeswapV2RestrictedStrategyPartialCloseMinimizeTrading is
     uint256 amountToRepayDebt
   );
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(
       okWorkers[msg.sender],
@@ -59,7 +60,7 @@ contract PancakeswapV2RestrictedStrategyPartialCloseMinimizeTrading is
   }
 
   /// @dev Create a new withdraw minimize trading strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   /// @param _wbnb The wrapped BNB token.
   /// @param _wNativeRelayer The relayer to support native transfer
   function initialize(
@@ -106,14 +107,14 @@ contract PancakeswapV2RestrictedStrategyPartialCloseMinimizeTrading is
       debt >= toRepaidBaseTokenDebt,
       "PancakeswapV2RestrictedStrategyPartialCloseMinimizeTrading::execute:: amount to repay debt is greater than debt"
     );
-    address[] memory path = new address[](2);
-    path[0] = farmingToken;
-    path[1] = baseToken;
     {
       uint256 balance = baseToken.myBalance();
       uint256 farmingTokenbalance = farmingToken.myBalance();
       if (toRepaidBaseTokenDebt > balance) {
         // Convert some farming tokens to base token.
+        address[] memory path = new address[](2);
+        path[0] = farmingToken;
+        path[1] = baseToken;
         uint256 remainingDebt = toRepaidBaseTokenDebt.sub(balance);
         uint256[] memory farmingTokenToBeRepaidDebts = router.getAmountsIn(remainingDebt, path);
         require(

--- a/contracts/6/protocol/strategies/pancakeswapV2/PancakeswapV2StrategyAddTwoSidesOptimalMigrate.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2/PancakeswapV2StrategyAddTwoSidesOptimalMigrate.sol
@@ -35,7 +35,7 @@ contract PancakeswapV2StrategyAddTwoSidesOptimalMigrate is ReentrancyGuardUpgrad
   IPancakeRouter02 public router;
 
   /// @dev Create a new add two-side optimal strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) external initializer {
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
 
@@ -92,13 +92,14 @@ contract PancakeswapV2StrategyAddTwoSidesOptimalMigrate is ReentrancyGuardUpgrad
 
   /// @dev Execute worker strategy. Take BaseToken + FarmingToken. Return LP tokens.
   /// @param data Extra calldata information passed along to this strategy.
-  function execute(address /* user */, uint256, /* debt */ bytes calldata data) external override nonReentrant
-  {
+  function execute(
+    address, /* user */
+    uint256,
+    /* debt */
+    bytes calldata data
+  ) external override nonReentrant {
     // 1. Find out what farming token we are dealing with.
-    (
-        address baseToken,
-        address farmingToken
-    ) = abi.decode(data, (address, address));
+    (address baseToken, address farmingToken) = abi.decode(data, (address, address));
     IPancakePair lpToken = IPancakePair(factory.getPair(farmingToken, baseToken));
     // 2. Approve router to do their stuffs
     baseToken.safeApprove(address(router), uint256(-1));
@@ -110,7 +111,12 @@ contract PancakeswapV2StrategyAddTwoSidesOptimalMigrate is ReentrancyGuardUpgrad
     {
       (uint256 r0, uint256 r1, ) = lpToken.getReserves();
       (uint256 baseTokenReserve, uint256 farmingTokenReserve) = lpToken.token0() == baseToken ? (r0, r1) : (r1, r0);
-      (swapAmt, isReversed) = optimalDeposit(baseTokenBalance, farmingToken.myBalance(), baseTokenReserve, farmingTokenReserve);
+      (swapAmt, isReversed) = optimalDeposit(
+        baseTokenBalance,
+        farmingToken.myBalance(),
+        baseTokenReserve,
+        farmingTokenReserve
+      );
     }
     // 4. Convert between BaseToken and farming tokens
     address[] memory path = new address[](2);
@@ -119,12 +125,21 @@ contract PancakeswapV2StrategyAddTwoSidesOptimalMigrate is ReentrancyGuardUpgrad
     if (swapAmt > 0) router.swapExactTokensForTokens(swapAmt, 0, path, address(this), now);
     // 6. Mint more LP tokens and return all LP tokens to the sender.
     router.addLiquidity(
-      baseToken, farmingToken, baseToken.myBalance(), farmingToken.myBalance(), 0, 0, address(this), now
+      baseToken,
+      farmingToken,
+      baseToken.myBalance(),
+      farmingToken.myBalance(),
+      0,
+      0,
+      address(this),
+      now
     );
-    require(lpToken.transfer(msg.sender, lpToken.balanceOf(address(this))), "PancakeswapV2StrategyAddTwoSidesOptimalMigrate::execute:: failed to transfer LP token to msg.sender");
+    require(
+      lpToken.transfer(msg.sender, lpToken.balanceOf(address(this))),
+      "PancakeswapV2StrategyAddTwoSidesOptimalMigrate::execute:: failed to transfer LP token to msg.sender"
+    );
     // 7. Reset approve to 0 for safety reason
     farmingToken.safeApprove(address(router), 0);
     baseToken.safeApprove(address(router), 0);
   }
-
 }

--- a/contracts/6/protocol/strategies/pancakeswapV2/PancakeswapV2StrategyLiquidate.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2/PancakeswapV2StrategyLiquidate.sol
@@ -31,7 +31,7 @@ contract PancakeswapV2StrategyLiquidate is ReentrancyGuardUpgradeSafe, IStrategy
   IPancakeRouter02 public router;
 
   /// @dev Create a new liquidate strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) external initializer {
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
 
@@ -41,20 +41,19 @@ contract PancakeswapV2StrategyLiquidate is ReentrancyGuardUpgradeSafe, IStrategy
 
   /// @dev Execute worker strategy. Take LP token. Return  BaseToken.
   /// @param data Extra calldata information passed along to this strategy.
-  function execute(address /* user */, uint256 /* debt */, bytes calldata data)
-    external
-    override
-    nonReentrant
-  {
+  function execute(
+    address, /* user */
+    uint256, /* debt */
+    bytes calldata data
+  ) external override nonReentrant {
     // 1. Find out what farming token we are dealing with.
-    (
-      address baseToken,
-      address farmingToken,
-      uint256 minBaseToken
-    ) = abi.decode(data, (address, address, uint256));
+    (address baseToken, address farmingToken, uint256 minBaseToken) = abi.decode(data, (address, address, uint256));
     IPancakePair lpToken = IPancakePair(factory.getPair(farmingToken, baseToken));
     // 2. Approve router to do their stuffs
-    require(lpToken.approve(address(router), uint256(-1)), "PancakeswapV2StrategyLiquidate::execute:: unable to approve LP token");
+    require(
+      lpToken.approve(address(router), uint256(-1)),
+      "PancakeswapV2StrategyLiquidate::execute:: unable to approve LP token"
+    );
     farmingToken.safeApprove(address(router), uint256(-1));
     // 3. Remove all liquidity back to BaseToken and farming tokens.
     router.removeLiquidity(baseToken, farmingToken, lpToken.balanceOf(address(this)), 0, 0, address(this), now);
@@ -68,7 +67,10 @@ contract PancakeswapV2StrategyLiquidate is ReentrancyGuardUpgradeSafe, IStrategy
     require(balance >= minBaseToken, "PancakeswapV2StrategyLiquidate::execute:: insufficient baseToken received");
     SafeToken.safeTransfer(baseToken, msg.sender, balance);
     // 6. Reset approve for safety reason
-    require(lpToken.approve(address(router), 0), "PancakeswapV2StrategyLiquidate::execute:: unable to reset LP token approval");
+    require(
+      lpToken.approve(address(router), 0),
+      "PancakeswapV2StrategyLiquidate::execute:: unable to reset LP token approval"
+    );
     farmingToken.safeApprove(address(router), 0);
   }
 }

--- a/contracts/6/protocol/strategies/pancakeswapV2/PancakeswapV2StrategyPartialCloseLiquidate.sol
+++ b/contracts/6/protocol/strategies/pancakeswapV2/PancakeswapV2StrategyPartialCloseLiquidate.sol
@@ -31,7 +31,7 @@ contract PancakeswapV2StrategyPartialCloseLiquidate is ReentrancyGuardUpgradeSaf
   IPancakeRouter02 public router;
 
   /// @dev Create a new liquidate strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The PancakeSwap Router smart contract.
   function initialize(IPancakeRouter02 _router) public initializer {
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
 
@@ -41,22 +41,21 @@ contract PancakeswapV2StrategyPartialCloseLiquidate is ReentrancyGuardUpgradeSaf
 
   /// @dev Execute worker strategy. Take LP token. Return  BaseToken.
   /// @param data Extra calldata information passed along to this strategy.
-  function execute(address /* user */, uint256 /* debt */, bytes calldata data)
-    external
-    override
-    nonReentrant
-  {
+  function execute(
+    address, /* user */
+    uint256, /* debt */
+    bytes calldata data
+  ) external override nonReentrant {
     // 1. Find out what farming token we are dealing with.
-    (
-      address baseToken,
-      address farmingToken,
-      uint256 returnLpToken,
-      uint256 minBaseToken
-    ) = abi.decode(data, (address, address, uint256, uint256));
+    (address baseToken, address farmingToken, uint256 returnLpToken, uint256 minBaseToken) =
+      abi.decode(data, (address, address, uint256, uint256));
     IPancakePair lpToken = IPancakePair(factory.getPair(farmingToken, baseToken));
-    require(lpToken.balanceOf(address(this)) >= returnLpToken, "PancakeswapV2StrategyPartialCloseLiquidate::execute:: insufficient LP amount recevied from worker");
+    require(
+      lpToken.balanceOf(address(this)) >= returnLpToken,
+      "PancakeswapV2StrategyPartialCloseLiquidate::execute:: insufficient LP amount recevied from worker"
+    );
     // 2. Approve router to do their stuffs
-    lpToken.approve(address(router), uint256(-1));
+    address(lpToken).safeApprove(address(router), uint256(-1));
     farmingToken.safeApprove(address(router), uint256(-1));
     // 3. Remove some LP back to BaseToken and farming tokens as we want to return some of the position.
     router.removeLiquidity(baseToken, farmingToken, returnLpToken, 0, 0, address(this), now);
@@ -67,11 +66,14 @@ contract PancakeswapV2StrategyPartialCloseLiquidate is ReentrancyGuardUpgradeSaf
     router.swapExactTokensForTokens(farmingToken.myBalance(), 0, path, address(this), now);
     // 5. Return all baseToken back to the original caller.
     uint256 balance = baseToken.myBalance();
-    require(balance >= minBaseToken, "PancakeswapV2StrategyPartialCloseLiquidate::execute:: insufficient baseToken received");
+    require(
+      balance >= minBaseToken,
+      "PancakeswapV2StrategyPartialCloseLiquidate::execute:: insufficient baseToken received"
+    );
     SafeToken.safeTransfer(baseToken, msg.sender, balance);
-    lpToken.transfer(msg.sender, lpToken.balanceOf(address(this)));
+    address(lpToken).safeTransfer(msg.sender, lpToken.balanceOf(address(this)));
     // 6. Reset approve for safety reason
-    lpToken.approve(address(router), 0);
+    address(lpToken).safeApprove(address(router), 0);
     farmingToken.safeApprove(address(router), 0);
   }
 }

--- a/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyAddBaseTokenOnly.sol
+++ b/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyAddBaseTokenOnly.sol
@@ -35,14 +35,14 @@ contract WaultSwapRestrictedStrategyAddBaseTokenOnly is OwnableUpgradeSafe, Reen
   IWaultSwapRouter02 public router;
   mapping(address => bool) public okWorkers;
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(okWorkers[msg.sender], "WaultSwapRestrictedStrategyAddBaseTokenOnly::onlyWhitelistedWorkers:: bad worker");
     _;
   }
 
   /// @dev Create a new add Token only strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The WaultSwap Router smart contract.
   function initialize(IWaultSwapRouter02 _router) external initializer {
     OwnableUpgradeSafe.__Ownable_init();
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();

--- a/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyAddTwoSidesOptimal.sol
+++ b/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyAddTwoSidesOptimal.sol
@@ -39,7 +39,7 @@ contract WaultSwapRestrictedStrategyAddTwoSidesOptimal is OwnableUpgradeSafe, Re
 
   mapping(address => bool) public okWorkers;
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(
       okWorkers[msg.sender],
@@ -49,7 +49,7 @@ contract WaultSwapRestrictedStrategyAddTwoSidesOptimal is OwnableUpgradeSafe, Re
   }
 
   /// @dev Create a new add two-side optimal strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The WaultSwap Router smart contract.
   function initialize(IWaultSwapRouter02 _router, IVault _vault) external initializer {
     OwnableUpgradeSafe.__Ownable_init();
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();

--- a/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyLiquidate.sol
+++ b/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyLiquidate.sol
@@ -34,14 +34,14 @@ contract WaultSwapRestrictedStrategyLiquidate is OwnableUpgradeSafe, ReentrancyG
 
   mapping(address => bool) public okWorkers;
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(okWorkers[msg.sender], "WaultSwapRestrictedStrategyLiquidate::onlyWhitelistedWorkers:: bad worker");
     _;
   }
 
   /// @dev Create a new liquidate strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The WaultSwap Router smart contract.
   function initialize(IWaultSwapRouter02 _router) external initializer {
     OwnableUpgradeSafe.__Ownable_init();
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();

--- a/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyPartialCloseLiquidate.sol
+++ b/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyPartialCloseLiquidate.sol
@@ -13,18 +13,17 @@ Alpaca Fin Corporation
 
 pragma solidity 0.6.6;
 
-import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
 
+import "../../apis/wault/IWaultSwapRouter02.sol";
 import "../../apis/wault/IWaultSwapFactory.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
-import "../../apis/wault/IWaultSwapRouter02.sol";
 import "../../interfaces/IStrategy.sol";
-import "../../../utils/SafeToken.sol";
 import "../../interfaces/IWorker.sol";
+
+import "../../../utils/SafeToken.sol";
 
 contract WaultSwapRestrictedStrategyPartialCloseLiquidate is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IStrategy {
   using SafeToken for address;
@@ -40,7 +39,7 @@ contract WaultSwapRestrictedStrategyPartialCloseLiquidate is OwnableUpgradeSafe,
     uint256 amounToLiquidate
   );
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(
       okWorkers[msg.sender],
@@ -50,7 +49,7 @@ contract WaultSwapRestrictedStrategyPartialCloseLiquidate is OwnableUpgradeSafe,
   }
 
   /// @dev Create a new liquidate strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The WaultSwap Router smart contract.
   function initialize(IWaultSwapRouter02 _router) public initializer {
     OwnableUpgradeSafe.__Ownable_init();
     ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
@@ -92,7 +91,7 @@ contract WaultSwapRestrictedStrategyPartialCloseLiquidate is OwnableUpgradeSafe,
       "WaultSwapRestrictedStrategyPartialCloseLiquidate::execute:: insufficient baseToken received"
     );
     SafeToken.safeTransfer(baseToken, msg.sender, balance);
-    lpToken.transfer(msg.sender, lpToken.balanceOf(address(this)));
+    address(lpToken).safeTransfer(msg.sender, lpToken.balanceOf(address(this)));
     // 6. Reset approve for safety reason
     address(lpToken).safeApprove(address(router), 0);
     farmingToken.safeApprove(address(router), 0);

--- a/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyPartialCloseLiquidate.sol
+++ b/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyPartialCloseLiquidate.sol
@@ -18,7 +18,6 @@ import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard
 
 import "../../apis/wault/IWaultSwapRouter02.sol";
 import "../../apis/wault/IWaultSwapFactory.sol";
-import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
 import "../../interfaces/IStrategy.sol";
 import "../../interfaces/IWorker.sol";

--- a/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyPartialCloseMinimizeTrading.sol
+++ b/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyPartialCloseMinimizeTrading.sol
@@ -19,7 +19,6 @@ import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 
 import "../../apis/wault/IWaultSwapRouter02.sol";
 import "../../apis/wault/IWaultSwapFactory.sol";
-import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
 import "../../interfaces/IStrategy.sol";
 import "../../interfaces/IWETH.sol";

--- a/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyPartialCloseMinimizeTrading.sol
+++ b/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyPartialCloseMinimizeTrading.sol
@@ -13,20 +13,20 @@ Alpaca Fin Corporation
 
 pragma solidity 0.6.6;
 
-import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
-import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 
+import "../../apis/wault/IWaultSwapRouter02.sol";
 import "../../apis/wault/IWaultSwapFactory.sol";
 import "@pancakeswap-libs/pancake-swap-core/contracts/interfaces/IPancakePair.sol";
 
-import "../../apis/wault/IWaultSwapRouter02.sol";
 import "../../interfaces/IStrategy.sol";
 import "../../interfaces/IWETH.sol";
 import "../../interfaces/IWNativeRelayer.sol";
-import "../../../utils/SafeToken.sol";
 import "../../interfaces/IWorker.sol";
+
+import "../../../utils/SafeToken.sol";
 
 contract WaultSwapRestrictedStrategyPartialCloseMinimizeTrading is
   OwnableUpgradeSafe,
@@ -50,7 +50,7 @@ contract WaultSwapRestrictedStrategyPartialCloseMinimizeTrading is
     uint256 amountToRepayDebt
   );
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(
       okWorkers[msg.sender],
@@ -60,7 +60,7 @@ contract WaultSwapRestrictedStrategyPartialCloseMinimizeTrading is
   }
 
   /// @dev Create a new withdraw minimize trading strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The WaultSwap Router smart contract.
   /// @param _wbnb The wrapped BNB token.
   /// @param _wNativeRelayer The relayer to support native transfer
   function initialize(
@@ -106,14 +106,14 @@ contract WaultSwapRestrictedStrategyPartialCloseMinimizeTrading is
       debt >= toRepaidBaseTokenDebt,
       "WaultSwapRestrictedStrategyPartialCloseMinimizeTrading::execute:: amount to repay debt is greater than debt"
     );
-    address[] memory path = new address[](2);
-    path[0] = farmingToken;
-    path[1] = baseToken;
     {
       uint256 balance = baseToken.myBalance();
       uint256 farmingTokenbalance = farmingToken.myBalance();
       if (toRepaidBaseTokenDebt > balance) {
         // Convert some farming tokens to base token.
+        address[] memory path = new address[](2);
+        path[0] = farmingToken;
+        path[1] = baseToken;
         uint256 remainingDebt = toRepaidBaseTokenDebt.sub(balance);
         uint256[] memory farmingTokenToBeRepaidDebts = router.getAmountsIn(remainingDebt, path);
         require(

--- a/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyWithdrawMinimizeTrading.sol
+++ b/contracts/6/protocol/strategies/waultswap-restricted/WaultSwapRestrictedStrategyWithdrawMinimizeTrading.sol
@@ -43,7 +43,7 @@ contract WaultSwapRestrictedStrategyWithdrawMinimizeTrading is
 
   mapping(address => bool) public okWorkers;
 
-  // @notice require that only allowed workers are able to do the rest of the method call
+  /// @notice require that only allowed workers are able to do the rest of the method call
   modifier onlyWhitelistedWorkers() {
     require(
       okWorkers[msg.sender],
@@ -53,7 +53,7 @@ contract WaultSwapRestrictedStrategyWithdrawMinimizeTrading is
   }
 
   /// @dev Create a new withdraw minimize trading strategy instance.
-  /// @param _router The Uniswap router smart contract.
+  /// @param _router The WaultSwap Router smart contract.
   /// @param _wbnb The wrapped BNB token.
   /// @param _wNativeRelayer The relayer to support native transfer
   function initialize(


### PR DESCRIPTION
## Description
Resolved issues raised by the auditor during Partial Close strategies audit.

## Why?
Make contracts even more secured.

## ChangeLogs:
- Using `safeTransfer` instead of `transfer` when working with `lpToken` in Partial Close contracts
- Reduced scope variables by re-order variables declaration.
- Better way to handling slippage in `Partial Close Single Asset Liquidate`
