### PR TITLE
[main][improve] Add killFactor sanity check when `addCollateral`

### DIFF
--- a/contracts/6/protocol/Vault.sol
+++ b/contracts/6/protocol/Vault.sol
@@ -30,6 +30,8 @@ import "../utils/SafeToken.sol";
 import "./interfaces/IWETH.sol";
 import "./interfaces/IWNativeRelayer.sol";
 
+import "hardhat/console.sol";
+
 contract Vault is IVault, ERC20UpgradeSafe, ReentrancyGuardUpgradeSafe, OwnableUpgradeSafe {
   /// @notice Libraries
   using SafeToken for address;
@@ -306,10 +308,13 @@ contract Vault is IVault, ERC20UpgradeSafe, ReentrancyGuardUpgradeSafe, OwnableU
     // - if not goRouge then check worker stability else only check reserve consistency.
     // - back must be 0 as it is adding collateral only. No BTOKEN needed to be returned.
     // - healthAfter must more than before.
+    // - debt ratio must below kill factor - 1%
     if (!goRogue) require(config.isWorkerStable(worker), "worker !stable");
     else require(config.isWorkerReserveConsistent(worker), "reserve !consistent");
     require(back == 0, "back !0");
     require(healthAfter > healthBefore, "health !increase");
+    uint256 killFactor = config.killFactor(pos.worker, debt);
+    require(debt.mul(10000) <= healthAfter.mul(killFactor.sub(100)), "debtRatio > killFactor margin");
     // 7. Release execution scope
     POSITION_ID = _NO_ID;
     STRATEGY = _NO_ADDRESS;

--- a/contracts/6/protocol/Vault.sol
+++ b/contracts/6/protocol/Vault.sol
@@ -30,8 +30,6 @@ import "../utils/SafeToken.sol";
 import "./interfaces/IWETH.sol";
 import "./interfaces/IWNativeRelayer.sol";
 
-import "hardhat/console.sol";
-
 contract Vault is IVault, ERC20UpgradeSafe, ReentrancyGuardUpgradeSafe, OwnableUpgradeSafe {
   /// @notice Libraries
   using SafeToken for address;

--- a/contracts/6/protocol/workers/WorkerConfig.sol
+++ b/contracts/6/protocol/workers/WorkerConfig.sol
@@ -127,8 +127,8 @@ contract WorkerConfig is OwnableUpgradeSafe, IWorkerConfig {
     require(lastUpdate >= now - 1 days, "WorkerConfig::isStable:: price too stale");
     uint256 lpPrice = r1.mul(1e18).div(r0);
     uint256 maxPriceDiff = workers[worker].maxPriceDiff;
-    require(lpPrice <= price.mul(maxPriceDiff).div(10000), "WorkerConfig::isStable:: price too high");
-    require(lpPrice >= price.mul(10000).div(maxPriceDiff), "WorkerConfig::isStable:: price too low");
+    require(lpPrice.mul(10000) <= price.mul(maxPriceDiff), "WorkerConfig::isStable:: price too high");
+    require(lpPrice.mul(maxPriceDiff) >= price.mul(10000), "WorkerConfig::isStable:: price too low");
     // 3. Done
     return true;
   }

--- a/test/Vault_PancakeswapV202.test.ts
+++ b/test/Vault_PancakeswapV202.test.ts
@@ -3068,6 +3068,31 @@ describe("Vault - PancakeswapV202", () => {
           ).to.be.bignumber.eq(debrisFtoken);
         }
 
+        async function revertNotEnoughCollateral(goRouge: boolean, stratAddress: string) {
+          // Simulate price swing to make position under water
+          await farmToken.approve(routerV2.address, ethers.utils.parseEther("888"));
+          await routerV2.swapExactTokensForTokens(
+            ethers.utils.parseEther("888"),
+            "0",
+            [farmToken.address, baseToken.address],
+            deployerAddress,
+            FOREVER
+          );
+          // Add super small collateral that it would still under the water after collateral is getting added
+          await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther("0.000000000000000001"));
+          await expect(
+            vaultAsAlice.addCollateral(
+              1,
+              ethers.utils.parseEther("0.000000000000000001"),
+              goRouge,
+              ethers.utils.defaultAbiCoder.encode(
+                ["address", "bytes"],
+                [stratAddress, ethers.utils.defaultAbiCoder.encode(["uint256"], ["0"])]
+              )
+            )
+          ).to.be.revertedWith("debtRatio > killFactor margin");
+        }
+
         async function revertUnapprovedStrat(goRouge: boolean, stratAddress: string) {
           await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther("88"));
           await expect(
@@ -3106,6 +3131,10 @@ describe("Vault - PancakeswapV202", () => {
 
             it("should increase health when twosides strat is choosen", async () => {
               await successTwoSides(await TimeHelpers.latestBlockNumber(), false);
+            });
+
+            it("should revert when not enough collateral to pass kill factor", async () => {
+              await revertNotEnoughCollateral(false, addStrat.address);
             });
 
             it("should revert when using liquidate strat", async () => {
@@ -3175,6 +3204,10 @@ describe("Vault - PancakeswapV202", () => {
 
             it("should increase health when twosides strat is choosen", async () => {
               await successTwoSides((await TimeHelpers.latestBlockNumber()).sub(1), true);
+            });
+
+            it("should revert when not enough collateral to pass kill factor", async () => {
+              await revertNotEnoughCollateral(true, addStrat.address);
             });
 
             it("should revert when using liquidate strat", async () => {


### PR DESCRIPTION
## Description
- Improve `addCollateral` by adding killFactor sanity check when collateral is being added into the position. 
- Improve precision handling when check `maxPriceDiff`

## Why?
This will prevent the edge case where users do `addCollateral` when position is under water but the collateral that is being added not enough to bring the position back to life. If such a case happened, the position will get liquidated even if collateral is being added and users will get charge from liquidate fees.

## ChangeLogs:
- Vault.sol
- tests
