### PR TITLE
[main][test] add example when calling work as whitelisted contract

### DIFF
--- a/contracts/6/protocol/interfaces/IVault02.sol
+++ b/contracts/6/protocol/interfaces/IVault02.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+/**
+  ∩~~~~∩ 
+  ξ ･×･ ξ 
+  ξ　~　ξ 
+  ξ　　 ξ 
+  ξ　　 “~～~～〇 
+  ξ　　　　　　 ξ 
+  ξ ξ ξ~～~ξ ξ ξ 
+　 ξ_ξξ_ξ　ξ_ξξ_ξ
+Alpaca Fin Corporation
+*/
+
+pragma solidity 0.6.6;
+
+import "./IVault.sol";
+
+interface IVault02 is IVault {
+  function nextPositionID() external view returns (uint256);
+
+  function work(
+    uint256 id,
+    address worker,
+    uint256 principalAmount,
+    uint256 borrowAmount,
+    uint256 maxReturn,
+    bytes calldata data
+  ) external payable;
+}

--- a/contracts/6/protocol/mock/MockWorkCaller.sol
+++ b/contracts/6/protocol/mock/MockWorkCaller.sol
@@ -2,12 +2,18 @@ pragma solidity 0.6.6;
 
 import "../Vault.sol";
 import "../../utils/SafeToken.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
 
-contract MockWorkCaller {
+contract MockWorkCaller is Initializable {
   using SafeToken for address;
+  Vault public vault;
+
+  function initialize(Vault _vault) external initializer {
+    vault = _vault;
+    vault.token().safeApprove(address(vault), uint256(-1));
+  }
 
   function executeWork(
-    Vault vault,
     address worker,
     uint256 principalAmount,
     uint256 borrowAmount,
@@ -18,7 +24,6 @@ contract MockWorkCaller {
   ) external returns (uint256 positionID) {
     positionID = vault.nextPositionID();
 
-    vault.token().safeApprove(address(vault), uint256(-1));
     bytes memory stratData = abi.encode(farmingTokenAmount, minLpAmount);
     bytes memory vaultData = abi.encode(strat, stratData);
     vault.work(0, worker, principalAmount, borrowAmount, maxReturn, vaultData);

--- a/contracts/6/protocol/mock/MockWorkCaller.sol
+++ b/contracts/6/protocol/mock/MockWorkCaller.sol
@@ -1,0 +1,26 @@
+pragma solidity 0.6.6;
+
+import "../Vault.sol";
+import "../../utils/SafeToken.sol";
+
+contract MockWorkCaller {
+  using SafeToken for address;
+
+  function executeWork(
+    Vault vault,
+    address worker,
+    uint256 principalAmount,
+    uint256 borrowAmount,
+    uint256 maxReturn,
+    address strat,
+    uint256 farmingTokenAmount,
+    uint256 minLpAmount
+  ) external returns (uint256 positionID) {
+    positionID = vault.nextPositionID();
+
+    vault.token().safeApprove(address(vault), uint256(-1));
+    bytes memory stratData = abi.encode(farmingTokenAmount, minLpAmount);
+    bytes memory vaultData = abi.encode(strat, stratData);
+    vault.work(0, worker, principalAmount, borrowAmount, maxReturn, vaultData);
+  }
+}

--- a/contracts/6/protocol/mock/MockWorkCaller.sol
+++ b/contracts/6/protocol/mock/MockWorkCaller.sol
@@ -1,14 +1,14 @@
 pragma solidity 0.6.6;
 
-import "../Vault.sol";
+import "../interfaces/IVault02.sol";
 import "../../utils/SafeToken.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
 
 contract MockWorkCaller is Initializable {
   using SafeToken for address;
-  Vault public vault;
+  IVault02 public vault;
 
-  function initialize(Vault _vault) external initializer {
+  function initialize(IVault02 _vault) external initializer {
     vault = _vault;
     vault.token().safeApprove(address(vault), uint256(-1));
   }

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "test:pan2partialliquidate": "hardhat test --no-compile ./test/PancakeswapV2_StrategyPartialCloseLiquidate.test.ts",
     "test:pan2restrictedadd": "hardhat test --no-compile ./test/PancakeswapV2_Restricted_StrategyAddBaseTokenOnly.test.ts",
     "test:pan2restrictedtwoside": "hardhat test --no-compile ./test/PancakeswapV2_Restricted_StrategyAddTwoSidesOptimal.test.ts",
+    "test:pan2restrictedtwoside_asWhitelisted": "hardhat test --no-compile ./test/PancakeswapV2_Restricted_StrategyAddTwoSidesOptimal_asWhitelistedContract.test.ts",
     "test:pan2restrictedliquidate": "hardhat test --no-compile ./test/PancakeswapV2_Restricted_StrategyLiquidate.test.ts",
     "test:pan2restrictedpartialcloseliquidate": "hardhat test --no-compile ./test/PancakeswapV2_Restricted_StrategyPartialCloseLiquidate.test.ts",
     "test:pan2restrictedminimize": "hardhat test --no-compile ./test/PancakeswapV2_Restricted_StrategyWithdrawMinimizeTrading.test.ts",

--- a/test/PancakeswapV2_Restricted_StrategyAddTwoSidesOptimal_asWhitelistedContract.test.ts
+++ b/test/PancakeswapV2_Restricted_StrategyAddTwoSidesOptimal_asWhitelistedContract.test.ts
@@ -1,0 +1,387 @@
+import { ethers, upgrades, waffle } from "hardhat";
+import { Signer, BigNumberish, utils, Wallet, BigNumber } from "ethers";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import "@openzeppelin/test-helpers";
+import {
+  AlpacaToken,
+  AlpacaToken__factory,
+  CakeToken,
+  CakeToken__factory,
+  DebtToken,
+  DebtToken__factory,
+  FairLaunch,
+  FairLaunch__factory,
+  MockERC20,
+  MockERC20__factory,
+  PancakeFactory,
+  PancakeFactory__factory,
+  PancakeMasterChef,
+  PancakeMasterChef__factory,
+  PancakePair,
+  PancakePair__factory,
+  PancakeRouter,
+  PancakeRouter__factory,
+  PancakeswapV2StrategyAddBaseTokenOnly,
+  PancakeswapV2RestrictedStrategyAddTwoSidesOptimal,
+  PancakeswapV2RestrictedStrategyAddTwoSidesOptimal__factory,
+  PancakeswapV2StrategyLiquidate,
+  PancakeswapV2StrategyLiquidate__factory,
+  PancakeswapWorker,
+  PancakeswapWorker__factory,
+  SimpleVaultConfig,
+  SimpleVaultConfig__factory,
+  StrategyAddTwoSidesOptimal,
+  StrategyAddTwoSidesOptimal__factory,
+  StrategyLiquidate,
+  StrategyLiquidate__factory,
+  SyrupBar,
+  SyrupBar__factory,
+  Vault,
+  Vault__factory,
+  WETH,
+  WETH__factory,
+  WNativeRelayer,
+  WNativeRelayer__factory,
+  MockWorkCaller,
+  MockWorkCaller__factory,
+} from "../typechain";
+
+chai.use(solidity);
+const { expect } = chai;
+
+describe("PancakeswapV2 - StrategyAddTwoSidesOptimal", () => {
+  const FOREVER = "2000000000";
+  const MAX_ROUNDING_ERROR = Number("15");
+  const CAKE_REWARD_PER_BLOCK = ethers.utils.parseEther("0.076");
+  const ALPACA_REWARD_PER_BLOCK = ethers.utils.parseEther("5000");
+  const ALPACA_BONUS_LOCK_UP_BPS = 7000;
+  const REINVEST_BOUNTY_BPS = "100"; // 1% reinvest bounty
+  const RESERVE_POOL_BPS = "1000"; // 10% reserve pool
+  const KILL_PRIZE_BPS = "1000"; // 10% Kill prize
+  const INTEREST_RATE = "3472222222222"; // 30% per year
+  const MIN_DEBT_SIZE = "1";
+  const WORK_FACTOR = "7000";
+  const KILL_FACTOR = "8000";
+  const KILL_TREASURY_BPS = "100";
+
+  /// Pancakeswap-related instance(s)
+  let factoryV2: PancakeFactory;
+  let routerV2: PancakeRouter;
+  let lp: PancakePair;
+
+  /// Token-related instance(s)
+  let wbnb: WETH;
+  let baseToken: MockERC20;
+  let farmingToken: MockERC20;
+  let cake: CakeToken;
+  let syrup: SyrupBar;
+
+  /// Strategy-related instance(s)
+  let addStrat: PancakeswapV2RestrictedStrategyAddTwoSidesOptimal;
+  let liqStrat: PancakeswapV2StrategyLiquidate;
+
+  /// Vault-related instance(s)
+  let config: SimpleVaultConfig;
+  let wNativeRelayer: WNativeRelayer;
+  let vault: Vault;
+
+  /// FairLaunch-related instance(s)
+  let fairLaunch: FairLaunch;
+  let alpacaToken: AlpacaToken;
+
+  /// PancakeswapMasterChef-related instance(s)
+  let masterChef: PancakeMasterChef;
+  let poolId: number;
+  let pancakeswapWorker: PancakeswapWorker;
+
+  // Accounts
+  let deployer: Signer;
+  let alice: Signer;
+  let bob: Signer;
+  let eve: Signer;
+
+  // Contract Signer
+  let addStratAsAlice: PancakeswapV2RestrictedStrategyAddTwoSidesOptimal;
+  let addStratAsBob: PancakeswapV2RestrictedStrategyAddTwoSidesOptimal;
+
+  let baseTokenAsAlice: MockERC20;
+  let baseTokenAsBob: MockERC20;
+
+  let farmingTokenAsAlice: MockERC20;
+  let farmingTokenAsBob: MockERC20;
+
+  let vaultAsAlice: Vault;
+  let vaultAsBob: Vault;
+
+  let mockWorkCallerAsAlice: MockWorkCaller;
+
+  async function fixture() {
+    [deployer, alice, bob, eve] = await ethers.getSigners();
+
+    // Setup Pancakeswap
+    const PancakeFactoryV2 = (await ethers.getContractFactory("PancakeFactory", deployer)) as PancakeFactory__factory;
+    factoryV2 = await PancakeFactoryV2.deploy(await deployer.getAddress());
+    await factoryV2.deployed();
+
+    const WBNB = (await ethers.getContractFactory("WETH", deployer)) as WETH__factory;
+    wbnb = await WBNB.deploy();
+    await wbnb.deployed();
+
+    const PancakeRouterV2 = (await ethers.getContractFactory("PancakeRouterV2", deployer)) as PancakeRouter__factory;
+    routerV2 = await PancakeRouterV2.deploy(factoryV2.address, wbnb.address);
+    await routerV2.deployed();
+
+    /// Setup token stuffs
+    const MockERC20 = (await ethers.getContractFactory("MockERC20", deployer)) as MockERC20__factory;
+    baseToken = (await upgrades.deployProxy(MockERC20, ["BTOKEN", "BTOKEN", 18])) as MockERC20;
+    await baseToken.deployed();
+    await baseToken.mint(await deployer.getAddress(), ethers.utils.parseEther("100"));
+    await baseToken.mint(await alice.getAddress(), ethers.utils.parseEther("100"));
+    await baseToken.mint(await bob.getAddress(), ethers.utils.parseEther("100"));
+    farmingToken = (await upgrades.deployProxy(MockERC20, ["FTOKEN", "FTOKEN", 18])) as MockERC20;
+    await farmingToken.deployed();
+    await farmingToken.mint(await deployer.getAddress(), ethers.utils.parseEther("100"));
+    await farmingToken.mint(await alice.getAddress(), ethers.utils.parseEther("100"));
+    await farmingToken.mint(await bob.getAddress(), ethers.utils.parseEther("100"));
+
+    const CakeToken = (await ethers.getContractFactory("CakeToken", deployer)) as CakeToken__factory;
+    cake = await CakeToken.deploy();
+    await cake.deployed();
+    await cake["mint(address,uint256)"](await deployer.getAddress(), ethers.utils.parseEther("100"));
+
+    const SyrupBar = (await ethers.getContractFactory("SyrupBar", deployer)) as SyrupBar__factory;
+    syrup = await SyrupBar.deploy(cake.address);
+    await syrup.deployed();
+
+    /// Setup BTOKEN-FTOKEN pair on Pancakeswap
+    await factoryV2.createPair(farmingToken.address, baseToken.address);
+    lp = PancakePair__factory.connect(await factoryV2.getPair(baseToken.address, farmingToken.address), deployer);
+    await lp.deployed();
+
+    /// Setup BTOKEN-FTOKEN pair on Pancakeswap
+    await factoryV2.createPair(wbnb.address, farmingToken.address);
+
+    // Setup FairLaunch contract
+    // Deploy ALPACAs
+    const AlpacaToken = (await ethers.getContractFactory("AlpacaToken", deployer)) as AlpacaToken__factory;
+    alpacaToken = await AlpacaToken.deploy(132, 137);
+    await alpacaToken.deployed();
+
+    const FairLaunch = (await ethers.getContractFactory("FairLaunch", deployer)) as FairLaunch__factory;
+    fairLaunch = await FairLaunch.deploy(
+      alpacaToken.address,
+      await alice.getAddress(),
+      ALPACA_REWARD_PER_BLOCK,
+      0,
+      ALPACA_BONUS_LOCK_UP_BPS,
+      0
+    );
+    await fairLaunch.deployed();
+
+    await alpacaToken.transferOwnership(fairLaunch.address);
+
+    // Config & Deploy Vault ibBTOKEN
+    // Create a new instance of BankConfig & Vault
+    const WNativeRelayer = (await ethers.getContractFactory("WNativeRelayer", deployer)) as WNativeRelayer__factory;
+    wNativeRelayer = await WNativeRelayer.deploy(wbnb.address);
+    await wNativeRelayer.deployed();
+
+    const SimpleVaultConfig = (await ethers.getContractFactory(
+      "SimpleVaultConfig",
+      deployer
+    )) as SimpleVaultConfig__factory;
+    config = (await upgrades.deployProxy(SimpleVaultConfig, [
+      MIN_DEBT_SIZE,
+      INTEREST_RATE,
+      RESERVE_POOL_BPS,
+      KILL_PRIZE_BPS,
+      wbnb.address,
+      wNativeRelayer.address,
+      fairLaunch.address,
+      KILL_TREASURY_BPS,
+      await eve.getAddress(),
+    ])) as SimpleVaultConfig;
+    await config.deployed();
+
+    const DebtToken = (await ethers.getContractFactory("DebtToken", deployer)) as DebtToken__factory;
+    const debtToken = (await upgrades.deployProxy(DebtToken, [
+      "debtibBTOKEN_V2",
+      "debtibBTOKEN_V2",
+      await deployer.getAddress(),
+    ])) as DebtToken;
+    await debtToken.deployed();
+
+    const Vault = (await ethers.getContractFactory("Vault", deployer)) as Vault__factory;
+    vault = (await upgrades.deployProxy(Vault, [
+      config.address,
+      baseToken.address,
+      "Interest Bearing BTOKEN",
+      "ibBTOKEN",
+      18,
+      debtToken.address,
+    ])) as Vault;
+    await vault.deployed();
+
+    await wNativeRelayer.setCallerOk([vault.address], true);
+
+    // Transfer ownership to vault
+    await debtToken.setOkHolders([vault.address, fairLaunch.address], true);
+    await debtToken.transferOwnership(vault.address);
+
+    // Set add FairLaunch poool and set fairLaunchPoolId for Vault
+    await fairLaunch.addPool(1, await vault.debtToken(), false);
+    await vault.setFairLaunchPoolId(0);
+
+    /// Setup strategy
+    const PancakeswapV2RestrictedStrategyAddTwoSidesOptimal = (await ethers.getContractFactory(
+      "PancakeswapV2RestrictedStrategyAddTwoSidesOptimal",
+      deployer
+    )) as PancakeswapV2RestrictedStrategyAddTwoSidesOptimal__factory;
+    addStrat = (await upgrades.deployProxy(PancakeswapV2RestrictedStrategyAddTwoSidesOptimal, [
+      routerV2.address,
+      vault.address,
+    ])) as PancakeswapV2RestrictedStrategyAddTwoSidesOptimal;
+    await addStrat.deployed();
+
+    const PancakeswapV2StrategyLiquidate = (await ethers.getContractFactory(
+      "PancakeswapV2StrategyLiquidate",
+      deployer
+    )) as PancakeswapV2StrategyLiquidate__factory;
+    liqStrat = (await upgrades.deployProxy(PancakeswapV2StrategyLiquidate, [
+      routerV2.address,
+    ])) as PancakeswapV2StrategyLiquidate;
+    await liqStrat.deployed();
+
+    /// Setup MasterChef
+    const PancakeMasterChef = (await ethers.getContractFactory(
+      "PancakeMasterChef",
+      deployer
+    )) as PancakeMasterChef__factory;
+    masterChef = await PancakeMasterChef.deploy(
+      cake.address,
+      syrup.address,
+      await deployer.getAddress(),
+      CAKE_REWARD_PER_BLOCK,
+      0
+    );
+    await masterChef.deployed();
+    // Transfer ownership so masterChef can mint CAKE
+    await cake.transferOwnership(masterChef.address);
+    await syrup.transferOwnership(masterChef.address);
+    // Add lp to masterChef's pool
+    await masterChef.add(1, lp.address, false);
+
+    /// Setup PancakeswapWorker
+    poolId = 1;
+    const PancakeswapWorker = (await ethers.getContractFactory(
+      "PancakeswapWorker",
+      deployer
+    )) as PancakeswapWorker__factory;
+    pancakeswapWorker = (await upgrades.deployProxy(PancakeswapWorker, [
+      vault.address,
+      baseToken.address,
+      masterChef.address,
+      routerV2.address,
+      poolId,
+      addStrat.address,
+      liqStrat.address,
+      REINVEST_BOUNTY_BPS,
+    ])) as PancakeswapWorker;
+    await pancakeswapWorker.deployed();
+    await config.setWorker(pancakeswapWorker.address, true, true, WORK_FACTOR, KILL_FACTOR, true, true);
+
+    await addStrat.setWorkersOk([pancakeswapWorker.address], true);
+
+    // Deployer adds 0.1 FTOKEN + 1 BTOKEN
+    await baseToken.approve(routerV2.address, ethers.utils.parseEther("1"));
+    await farmingToken.approve(routerV2.address, ethers.utils.parseEther("0.1"));
+    await routerV2.addLiquidity(
+      baseToken.address,
+      farmingToken.address,
+      ethers.utils.parseEther("1"),
+      ethers.utils.parseEther("0.1"),
+      "0",
+      "0",
+      await deployer.getAddress(),
+      FOREVER
+    );
+
+    // Deployer adds 0.1 CAKE + 1 NATIVE
+    await cake.approve(routerV2.address, ethers.utils.parseEther("1"));
+    await routerV2.addLiquidityETH(
+      cake.address,
+      ethers.utils.parseEther("0.1"),
+      "0",
+      "0",
+      await deployer.getAddress(),
+      FOREVER,
+      { value: ethers.utils.parseEther("1") }
+    );
+
+    // Deployer adds 1 BTOKEN + 1 NATIVE
+    await baseToken.approve(routerV2.address, ethers.utils.parseEther("1"));
+    await routerV2.addLiquidityETH(
+      baseToken.address,
+      ethers.utils.parseEther("1"),
+      "0",
+      "0",
+      await deployer.getAddress(),
+      FOREVER,
+      { value: ethers.utils.parseEther("1") }
+    );
+
+    const MockWorkCaller = (await ethers.getContractFactory("MockWorkCaller", deployer)) as MockWorkCaller__factory;
+    const mockWorkCaller = (await upgrades.deployProxy(MockWorkCaller, [])) as MockWorkCaller;
+    await mockWorkCaller.deployed();
+
+    await baseToken.mint(await mockWorkCaller.address, ethers.utils.parseEther("100"));
+
+    // Contract signer
+    addStratAsAlice = PancakeswapV2RestrictedStrategyAddTwoSidesOptimal__factory.connect(addStrat.address, alice);
+    addStratAsBob = PancakeswapV2RestrictedStrategyAddTwoSidesOptimal__factory.connect(addStrat.address, bob);
+
+    baseTokenAsAlice = MockERC20__factory.connect(baseToken.address, alice);
+    baseTokenAsBob = MockERC20__factory.connect(baseToken.address, bob);
+
+    farmingTokenAsAlice = MockERC20__factory.connect(farmingToken.address, alice);
+    farmingTokenAsBob = MockERC20__factory.connect(farmingToken.address, bob);
+
+    vaultAsAlice = Vault__factory.connect(vault.address, alice);
+    vaultAsBob = Vault__factory.connect(vault.address, bob);
+
+    mockWorkCallerAsAlice = MockWorkCaller__factory.connect(mockWorkCaller.address, alice);
+  }
+
+  beforeEach(async () => {
+    await waffle.loadFixture(fixture);
+  });
+
+  it("should convert all BTOKEN to LP tokens at best rate from MockWorkCaller", async () => {
+    // Deployer deposits 3 BTOKEN to the vault
+    await baseToken.approve(vault.address, ethers.utils.parseEther("3"));
+    await vault.deposit(ethers.utils.parseEther("3"));
+
+    // Now Alice leverage 2x on her 1 BTOKEN.
+    // So totally Alice will take 1 BTOKEN from the pool and 1 BTOKEN from her pocket to
+    // Provide liquidity in the BTOKEN-FTOKEN pool on Pancakeswap
+    await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther("1"));
+
+    await config.setWhitelistedCallers([mockWorkCallerAsAlice.address], true);
+    await mockWorkCallerAsAlice.executeWork(
+      vault.address,
+      pancakeswapWorker.address,
+      ethers.utils.parseEther("1"),
+      ethers.utils.parseEther("1"),
+      "0",
+      addStrat.address,
+      ethers.utils.parseEther("0"),
+      ethers.utils.parseEther("0")
+    );
+
+    const masterChefLPBalanceRound1 = await lp.balanceOf(masterChef.address);
+    expect(masterChefLPBalanceRound1).to.be.bignumber.above(ethers.utils.parseEther("0"));
+    expect(await lp.balanceOf(addStrat.address)).to.be.bignumber.eq("0");
+    expect(await farmingToken.balanceOf(addStrat.address)).to.be.bignumber.below(MAX_ROUNDING_ERROR);
+  });
+});

--- a/test/PancakeswapV2_Restricted_StrategyAddTwoSidesOptimal_asWhitelistedContract.test.ts
+++ b/test/PancakeswapV2_Restricted_StrategyAddTwoSidesOptimal_asWhitelistedContract.test.ts
@@ -332,7 +332,7 @@ describe("PancakeswapV2 - StrategyAddTwoSidesOptimal", () => {
     );
 
     const MockWorkCaller = (await ethers.getContractFactory("MockWorkCaller", deployer)) as MockWorkCaller__factory;
-    const mockWorkCaller = (await upgrades.deployProxy(MockWorkCaller, [])) as MockWorkCaller;
+    const mockWorkCaller = (await upgrades.deployProxy(MockWorkCaller, [vault.address])) as MockWorkCaller;
     await mockWorkCaller.deployed();
 
     await baseToken.mint(await mockWorkCaller.address, ethers.utils.parseEther("100"));
@@ -369,7 +369,6 @@ describe("PancakeswapV2 - StrategyAddTwoSidesOptimal", () => {
 
     await config.setWhitelistedCallers([mockWorkCallerAsAlice.address], true);
     await mockWorkCallerAsAlice.executeWork(
-      vault.address,
       pancakeswapWorker.address,
       ethers.utils.parseEther("1"),
       ethers.utils.parseEther("1"),


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
Add an example on how to call `Vault.work()` from a whitelisted contract to open a position.

## Why?
Because current test has not cover this scenario and this would be a starting example for any protocol that wish to integrate with Alpaca's LYF product.

## ChangeLogs:
<!--- changes for this pr -->


### Link to story (if available)
<!--- Add story URL here -->
