### PR TITLE
[feat][feat]: remove error when send no lpAmount

### DIFF
--- a/contracts/8.10/protocol/DeltaNeutralOracle.sol
+++ b/contracts/8.10/protocol/DeltaNeutralOracle.sol
@@ -20,10 +20,8 @@ import "./interfaces/IDeltaNeutralOracle.sol";
 import "./interfaces/IChainLinkPriceOracle.sol";
 import "../utils/AlpacaMath.sol";
 
-error InvalidLPAmount();
 error InvalidLPAddress();
 error InvalidLPTotalSupply();
-error InvalidDollarAmount();
 
 contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgradeable {
   using AlpacaMath for uint256;
@@ -45,7 +43,7 @@ contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgrad
   /// @param _lpToken address of LP token
   function lpToDollar(uint256 _lpAmount, address _lpToken) external view returns (uint256, uint256) {
     if (_lpAmount == 0) {
-      revert InvalidLPAmount();
+      return (0, block.timestamp);
     }
     (uint256 _lpPrice, uint256 _lastUpdate) = _getLPPrice(_lpToken);
     return ((_lpAmount * _lpPrice) / (10**18), _lastUpdate);
@@ -57,7 +55,7 @@ contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgrad
   /// @param _lpToken address of LP token
   function dollarToLp(uint256 _dollarAmount, address _lpToken) external view returns (uint256, uint256) {
     if (_dollarAmount == 0) {
-      revert InvalidDollarAmount();
+      return (0, block.timestamp);
     }
     (uint256 _lpPrice, uint256 _lastUpdate) = _getLPPrice(_lpToken);
     return (((_dollarAmount * (10**18)) / _lpPrice), _lastUpdate);
@@ -81,7 +79,7 @@ contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgrad
 
     uint256 _totalSupply = ILiquidityPair(_lpToken).totalSupply();
     if (_totalSupply == 0) {
-      revert InvalidLPTotalSupply();
+      return (0, block.timestamp);
     }
 
     (uint256 _r0, uint256 _r1, ) = ILiquidityPair(_lpToken).getReserves();

--- a/contracts/8.10/protocol/DeltaNeutralOracle.sol
+++ b/contracts/8.10/protocol/DeltaNeutralOracle.sol
@@ -21,7 +21,6 @@ import "./interfaces/IChainLinkPriceOracle.sol";
 import "../utils/AlpacaMath.sol";
 
 error InvalidLPAddress();
-error InvalidLPTotalSupply();
 
 contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgradeable {
   using AlpacaMath for uint256;

--- a/scripts/fork/DeltaNeutralOracle.test.ts
+++ b/scripts/fork/DeltaNeutralOracle.test.ts
@@ -91,6 +91,11 @@ async function main() {
   const [dollarToLPResult] = await deltaNeutralOracle.dollarToLp(manualLpValue, lpWbnbBusdAddress);
   expect(dollarToLPResult).to.be.eq(ethers.constants.WeiPerEther);
 
+  const [lpAmount] = await deltaNeutralOracle.dollarToLp(ethers.constants.Zero, lpWbnbBusdAddress);
+  expect(lpAmount).to.be.eq(ethers.constants.Zero);
+  const [dollarAmount] = await deltaNeutralOracle.lpToDollar(ethers.constants.Zero, lpWbnbBusdAddress);
+  expect(dollarAmount).to.be.eq(ethers.constants.Zero);
+
   console.log("====== DONE ======");
 }
 

--- a/test/integrations/protocol/DeltaNeutralOracle.test.ts
+++ b/test/integrations/protocol/DeltaNeutralOracle.test.ts
@@ -318,11 +318,6 @@ context("chainlink get price should work properly", async () => {
 
 describe("#LPtoDollar", async () => {
   context("when invalid input", async () => {
-    it("should return 0 when no LP amount", async () => {
-      const [dollarAmount] = await priceOracle.lpToDollar(ethers.constants.Zero, lpV2Token0Stable0.address);
-      expect(dollarAmount).to.be.eq(ethers.constants.Zero);
-    });
-
     it("should revert when no address", async () => {
       await expect(priceOracle.lpToDollar(ethers.constants.One, ethers.constants.AddressZero)).to.be.revertedWith(
         "InvalidLPAddress()"
@@ -361,16 +356,15 @@ describe("#LPtoDollar", async () => {
         );
       }
     });
+    it("should return 0 when no LP amount", async () => {
+      const [dollarAmount] = await priceOracle.lpToDollar(ethers.constants.Zero, lpV2Token0Stable0.address);
+      expect(dollarAmount).to.be.eq(ethers.constants.Zero);
+    });
   });
 });
 
 describe("#dollarToLp", async () => {
   context("when incorrect input", async () => {
-    it("should return 0 when no LP amount", async () => {
-      const [lpResult] = await priceOracle.dollarToLp(ethers.constants.Zero, lpV2Token0Stable0.address);
-      expect(lpResult).to.be.eq(ethers.constants.Zero);
-    });
-
     it("should revert when no address", async () => {
       await expect(priceOracle.dollarToLp(ethers.constants.One, ethers.constants.AddressZero)).to.be.revertedWith(
         "InvalidLPAddress()"
@@ -409,6 +403,11 @@ describe("#dollarToLp", async () => {
           "0.03"
         );
       }
+    });
+
+    it("should return 0 when no LP amount", async () => {
+      const [lpResult] = await priceOracle.dollarToLp(ethers.constants.Zero, lpV2Token0Stable0.address);
+      expect(lpResult).to.be.eq(ethers.constants.Zero);
     });
   });
 });

--- a/test/integrations/protocol/DeltaNeutralOracle.test.ts
+++ b/test/integrations/protocol/DeltaNeutralOracle.test.ts
@@ -318,10 +318,9 @@ context("chainlink get price should work properly", async () => {
 
 describe("#LPtoDollar", async () => {
   context("when invalid input", async () => {
-    it("should revert when no LP amount", async () => {
-      await expect(priceOracle.lpToDollar(ethers.constants.Zero, lpV2Token0Stable0.address)).to.be.revertedWith(
-        "InvalidLPAmount()"
-      );
+    it("should return 0 when no LP amount", async () => {
+      const [dollarAmount] = await priceOracle.lpToDollar(ethers.constants.Zero, lpV2Token0Stable0.address);
+      expect(dollarAmount).to.be.eq(ethers.constants.Zero);
     });
 
     it("should revert when no address", async () => {
@@ -367,10 +366,9 @@ describe("#LPtoDollar", async () => {
 
 describe("#dollarToLp", async () => {
   context("when incorrect input", async () => {
-    it("should revert when no LP amount", async () => {
-      await expect(priceOracle.dollarToLp(ethers.constants.Zero, lpV2Token0Stable0.address)).to.be.revertedWith(
-        "InvalidDollarAmount()"
-      );
+    it("should return 0 when no LP amount", async () => {
+      const [lpResult] = await priceOracle.dollarToLp(ethers.constants.Zero, lpV2Token0Stable0.address);
+      expect(lpResult).to.be.eq(ethers.constants.Zero);
     });
 
     it("should revert when no address", async () => {


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
remove error when send no lpAmount.

## Why?
- to prevent when initialize and worker get LP and always revert.

## ChangeLogs:
<!--- changes for this pr -->


### Link to story (if available)
<!--- Add story URL here -->
