### PR TITLE
[main][fix] Use LP value - debt repaid in withdraw value calculation

### DIFF
--- a/contracts/8.10/protocol/DeltaNeutralVault.sol
+++ b/contracts/8.10/protocol/DeltaNeutralVault.sol
@@ -876,19 +876,6 @@ contract DeltaNeutralVault is ERC20Upgradeable, ReentrancyGuardUpgradeable, Owna
     return _price;
   }
 
-  /// @notice Calculate change in total equity.
-  /// @param _positionInfoBefore Previous position info
-  /// @param _positionInfoAfter Current position info
-  function _totalEquityGain(PositionInfo memory _positionInfoBefore, PositionInfo memory _positionInfoAfter)
-    internal
-    pure
-    returns (uint256)
-  {
-    return
-      (_positionInfoAfter.stablePositionEquity + _positionInfoAfter.assetPositionEquity) -
-      (_positionInfoBefore.stablePositionEquity + _positionInfoBefore.assetPositionEquity);
-  }
-
   /// @notice Calculate share from value and total equity
   /// @param _value Value to convert
   /// @param _totalEquity Total equity at the time of calculation

--- a/contracts/8.10/protocol/DeltaNeutralVault.sol
+++ b/contracts/8.10/protocol/DeltaNeutralVault.sol
@@ -390,8 +390,8 @@ contract DeltaNeutralVault is ERC20Upgradeable, ReentrancyGuardUpgradeable, Owna
     // and debt repaid = debt before - debt
     uint256 _withdrawValue = _calculateWithdrawValue(
       _totalUnderlyingLpBefore,
-      (_positionInfoBefore.assetPositionDebtValue + _positionInfoBefore.stablePositionDebtValue) -
-        (_positionInfoAfter.assetPositionDebtValue + _positionInfoAfter.stablePositionDebtValue)
+      (_positionInfoBefore.stablePositionDebtValue + _positionInfoBefore.assetPositionDebtValue) -
+        (_positionInfoAfter.stablePositionDebtValue + _positionInfoAfter.assetPositionDebtValue)
     );
 
     if (_withdrawShareValue < _withdrawValue) {

--- a/contracts/8.10/protocol/DeltaNeutralVault.sol
+++ b/contracts/8.10/protocol/DeltaNeutralVault.sol
@@ -722,8 +722,9 @@ contract DeltaNeutralVault is ERC20Upgradeable, ReentrancyGuardUpgradeable, Owna
 
   /// @notice Return equity value of delta neutral position.
   function totalEquityValue() public view returns (uint256) {
-    uint256 _totalPositionValue = _positionValue(IWorker02(stableVaultWorker).totalLpBalance()) +
-      _positionValue(IWorker02(assetVaultWorker).totalLpBalance());
+    uint256 _totalPositionValue = _positionValue(
+      IWorker02(stableVaultWorker).totalLpBalance() + IWorker02(assetVaultWorker).totalLpBalance()
+    );
     uint256 _totalDebtValue = _positionDebtValue(stableVault, stableVaultPosId, stableTo18ConversionFactor) +
       _positionDebtValue(assetVault, assetVaultPosId, assetTo18ConversionFactor);
     if (_totalPositionValue < _totalDebtValue) {

--- a/contracts/8.10/protocol/DeltaNeutralVault.sol
+++ b/contracts/8.10/protocol/DeltaNeutralVault.sol
@@ -312,11 +312,11 @@ contract DeltaNeutralVault is ERC20Upgradeable, ReentrancyGuardUpgradeable, Owna
 
     // 3. mint share for shareReceiver
     PositionInfo memory _positionInfoAfter = positionInfo();
-    uint256 _valueGain = _calculateValueGain(_positionInfoBefore, _positionInfoAfter);
+    uint256 _depositValue = _calculateDepositValue(_positionInfoBefore, _positionInfoAfter);
 
     // Calculate share from the value gain against the total equity before execution of actions
     uint256 _sharesToUser = _valueToShare(
-      _valueGain,
+      _depositValue,
       _positionInfoBefore.stablePositionEquity + _positionInfoBefore.assetPositionEquity
     );
 
@@ -327,7 +327,7 @@ contract DeltaNeutralVault is ERC20Upgradeable, ReentrancyGuardUpgradeable, Owna
     _mint(_shareReceiver, _sharesToUser);
 
     // 4. sanity check
-    _depositHealthCheck(_valueGain, _positionInfoBefore, _positionInfoAfter);
+    _depositHealthCheck(_depositValue, _positionInfoBefore, _positionInfoAfter);
     _outstandingCheck(_outstandingBefore, _outstanding());
 
     emit LogDeposit(msg.sender, _shareReceiver, _sharesToUser, _stableTokenAmount, _assetTokenAmount);
@@ -777,7 +777,7 @@ contract DeltaNeutralVault is ERC20Upgradeable, ReentrancyGuardUpgradeable, Owna
   /// @notice Return deposit value
   /// @param _positionInfoBefore Position information before execute.
   /// @param _positionInfoAfter Position information after execute.
-  function _calculateValueGain(PositionInfo memory _positionInfoBefore, PositionInfo memory _positionInfoAfter)
+  function _calculateDepositValue(PositionInfo memory _positionInfoBefore, PositionInfo memory _positionInfoAfter)
     internal
     view
     returns (uint256)
@@ -802,10 +802,10 @@ contract DeltaNeutralVault is ERC20Upgradeable, ReentrancyGuardUpgradeable, Owna
     uint256 _lpLoss = (_positionInfoBefore.stableLpAmount + _positionInfoBefore.assetLpAmount) -
       (_positionInfoAfter.stableLpAmount + _positionInfoAfter.assetLpAmount);
 
-    uint256 _debtRepaid = (_positionInfoBefore.stablePositionDebtValue + _positionInfoBefore.assetPositionDebtValue) -
+    uint256 _lessDebt = (_positionInfoBefore.stablePositionDebtValue + _positionInfoBefore.assetPositionDebtValue) -
       (_positionInfoAfter.stablePositionDebtValue + _positionInfoAfter.assetPositionDebtValue);
 
-    return _lpToValue(_lpLoss) - _debtRepaid;
+    return _lpToValue(_lpLoss) - _lessDebt;
   }
 
   /// @notice Proxy function for calling internal action.


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->
## Description
New calculation on withdraw value. Instead of using tokens return and assess the value. Use LP's value used in withdrawal - debt repaid.

## Why?
Old calculation lead to larger equity loss due to Worker's LP amount as an multiplier to position value changes


### Link to story (if available)
<!--- Add story URL here -->
ALPACA-3574