### PR TITLE
[main][feat] Revenue Treasury enhancement

### DIFF
--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -119,7 +119,7 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable {
 
       if (vaultSwapPath.length != 0) {
         uint256[] memory expectedAmountsIn = router.getAmountsIn(remaining, vaultSwapPath);
-        // if the exepected amount in < _split, swap _split amount
+        // if the exepected amount in < _split, then swap with _split amount
         // otherwise, swap only neeeded
         uint256 _swapAmount = expectedAmountsIn[0] < _split ? expectedAmountsIn[0] : _split;
         token.safeApprove(address(router), _swapAmount);

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -118,6 +118,7 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable {
       // The amount to transfer to vault should be equal to min(split , remaining)
 
       if (vaultSwapPath.length != 0) {
+        // find the amount in if we're going to cover all remaining
         uint256[] memory expectedAmountsIn = router.getAmountsIn(remaining, vaultSwapPath);
         // if the exepected amount in < _split, then swap with _split amount
         // otherwise, swap only neeeded

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -132,7 +132,7 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable {
           block.timestamp
         );
 
-        // update trasnfer amount by the amount received from swap
+        // update transfer amount by the amount received from swap
         _transferAmount = _amountsOut[_amountsOut.length - 1];
       } else {
         _transferAmount = _split < remaining ? _split : remaining;

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -141,7 +141,8 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable, ReentrancyGuardUp
         _transferAmount = _split < remaining ? _split : remaining;
       }
 
-      remaining = remaining - _transferAmount;
+      // _transferAmount is unlikely to > remaining, but have this check to handle if happened
+      remaining = _transferAmount < remaining ? remaining - _transferAmount : 0;
       vault.token().safeTransfer(address(vault), _transferAmount);
 
       emit LogSettleBadDebt(msg.sender, _transferAmount);

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -120,7 +120,7 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable {
       if (vaultSwapPath.length != 0) {
         // find the amount in if we're going to cover all remaining
         uint256[] memory expectedAmountsIn = router.getAmountsIn(remaining, vaultSwapPath);
-        // if the exepected amount in < _split, then swap with _split amount
+        // if the exepected amount in < _split, then swap with expeced amount in
         // otherwise, swap only neeeded
         uint256 _swapAmount = expectedAmountsIn[0] < _split ? expectedAmountsIn[0] : _split;
         token.safeApprove(address(router), _swapAmount);

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -131,9 +131,9 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable {
           address(this),
           block.timestamp
         );
-        _transferAmount = _amountsOut[_amountsOut.length - 1] < remaining
-          ? _amountsOut[_amountsOut.length - 1]
-          : remaining;
+
+        // update trasnfer amount by the amount received from swap
+        _transferAmount = _amountsOut[_amountsOut.length - 1];
       } else {
         _transferAmount = _split < remaining ? _split : remaining;
       }

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -117,6 +117,8 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable {
       uint256 split = (token.myBalance() * splitBps) / 10000;
       // The amount to transfer to vault shoule be equal to min(split , remaining)
       _transferAmount = split < remaining ? split : remaining;
+      remaining = remaining - _transferAmount;
+
       if (vaultSwapPath.length != 0) {
         token.safeApprove(address(router), _transferAmount);
         router.swapTokensForExactTokens(
@@ -127,7 +129,7 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable {
           block.timestamp
         );
       }
-      remaining = remaining - _transferAmount;
+
       vault.token().safeTransfer(address(vault), _transferAmount);
     }
 

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -65,7 +65,8 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable, ReentrancyGuardUp
   uint256 public splitBps;
 
   /// @notice Events
-  event LogFeedGrassHouse(address indexed _caller, uint256 _transferAmount, uint256 _feedAmount);
+  event LogSettleBadDebt(address indexed _caller, uint256 _transferAmount);
+  event LogFeedGrassHouse(address indexed _caller, uint256 _feedAmount);
   event LogSetToken(address indexed _caller, address _prevToken, address _newToken);
   event LogSetVault(address indexed _caller, address _prevVault, address _newVault);
   event LogSetGrassHouse(address indexed _caller, address _prevGrassHouse, address _newGrassHouse);
@@ -142,6 +143,8 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable, ReentrancyGuardUp
 
       remaining = remaining - _transferAmount;
       vault.token().safeTransfer(address(vault), _transferAmount);
+
+      emit LogSettleBadDebt(msg.sender, _transferAmount);
     }
 
     // Swap all the rest to reward token if needed
@@ -155,7 +158,7 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable, ReentrancyGuardUp
     uint256 _feedAmount = grasshouseToken.myBalance();
     grasshouseToken.safeApprove(address(grassHouse), _feedAmount);
     grassHouse.feed(_feedAmount);
-    emit LogFeedGrassHouse(msg.sender, _transferAmount, _feedAmount);
+    emit LogFeedGrassHouse(msg.sender, _feedAmount);
   }
 
   /// @notice Set new recieving token

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -13,6 +13,7 @@ Alpaca Fin Corporation
 
 pragma solidity 0.8.10;
 
+import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
@@ -24,7 +25,7 @@ import "./interfaces/IVault.sol";
 import "../utils/SafeToken.sol";
 
 /// @title RevenueTreasury - Receives Revenue and Settles Redistribution
-contract RevenueTreasury is Initializable, OwnableUpgradeable {
+contract RevenueTreasury is Initializable, OwnableUpgradeable, ReentrancyGuardUpgradeable {
   /// @notice Libraries
   using SafeToken for address;
 
@@ -106,7 +107,7 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable {
   }
 
   /// @notice Split fund and distribute
-  function feedGrassHouse() external {
+  function feedGrassHouse() external nonReentrant {
     //check
     _validateSwapPath(token, vault.token(), vaultSwapPath);
     _validateSwapPath(token, grasshouseToken, rewardPath);

--- a/contracts/8.10/protocol/RevenueTreasury.sol
+++ b/contracts/8.10/protocol/RevenueTreasury.sol
@@ -141,7 +141,7 @@ contract RevenueTreasury is Initializable, OwnableUpgradeable, ReentrancyGuardUp
       }
 
       // _transferAmount is unlikely to > remaining, but have this check to handle if happened
-      remaining = _transferAmount < remaining ? remaining - _transferAmount : 0;
+      remaining = remaining > _transferAmount ? remaining - _transferAmount : 0;
       vault.token().safeTransfer(address(vault), _transferAmount);
 
       emit LogSettleBadDebt(msg.sender, _transferAmount);

--- a/contracts/8.10/protocol/interfaces/ISwapRouter.sol
+++ b/contracts/8.10/protocol/interfaces/ISwapRouter.sol
@@ -46,4 +46,8 @@ interface ISwapRouter {
     address to,
     uint256 deadline
   ) external returns (uint256[] memory amounts);
+
+  function getAmountsIn(uint256 amountOut, address[] memory path) external view returns (uint256[] memory amounts);
+
+  function getAmountsOut(uint256 amountIn, address[] memory path) external view returns (uint256[] memory amounts);
 }

--- a/contracts/8.10/protocol/mocks/MockSwapRouter.sol
+++ b/contracts/8.10/protocol/mocks/MockSwapRouter.sol
@@ -61,12 +61,18 @@ contract MockSwapRouter is ISwapRouter {
   }
 
   function swapTokensForExactTokens(
-    uint256, /*amountOut*/
+    uint256 amountOut,
     uint256, /*amountInMax*/
-    address[] calldata, /*path*/
-    address, /*to*/
+    address[] calldata path,
+    address to,
     uint256 /*deadline*/
-  ) external pure returns (uint256[] memory amounts) {
+  ) external returns (uint256[] memory amounts) {
+    IERC20Upgradeable(path[0]).safeTransferFrom(msg.sender, address(this), amountOut);
+    IERC20Upgradeable(path[path.length - 1]).safeTransfer(to, amountOut);
+
+    amounts = new uint256[](2);
+    amounts[0] = amountOut;
+    amounts[1] = amountOut;
     return amounts;
   }
 }

--- a/contracts/8.10/protocol/mocks/MockSwapRouter.sol
+++ b/contracts/8.10/protocol/mocks/MockSwapRouter.sol
@@ -21,14 +21,6 @@ import "../interfaces/ISwapRouter.sol";
 contract MockSwapRouter is ISwapRouter {
   using SafeERC20Upgradeable for IERC20Upgradeable;
 
-  address public source;
-  address public destination;
-
-  constructor(address _source, address _destination) {
-    source = _source;
-    destination = _destination;
-  }
-
   function WETH() external pure returns (address) {
     return address(0);
   }
@@ -55,12 +47,12 @@ contract MockSwapRouter is ISwapRouter {
   function swapExactTokensForTokens(
     uint256 amountIn,
     uint256, /*amountOutMin*/
-    address[] calldata, /*path*/
+    address[] calldata path,
     address to,
     uint256 /*deadline*/
   ) external returns (uint256[] memory amounts) {
-    IERC20Upgradeable(source).safeTransferFrom(msg.sender, address(this), amountIn);
-    IERC20Upgradeable(destination).safeTransfer(to, amountIn);
+    IERC20Upgradeable(path[0]).safeTransferFrom(msg.sender, address(this), amountIn);
+    IERC20Upgradeable(path[path.length - 1]).safeTransfer(to, amountIn);
 
     amounts = new uint256[](2);
     amounts[0] = amountIn;

--- a/contracts/8.10/protocol/mocks/MockSwapRouter.sol
+++ b/contracts/8.10/protocol/mocks/MockSwapRouter.sol
@@ -18,6 +18,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 
 import "../interfaces/ISwapRouter.sol";
 
+/// @title MockSwapRouter - 1:1 swap for all token without fee and price impact
 contract MockSwapRouter is ISwapRouter {
   using SafeERC20Upgradeable for IERC20Upgradeable;
 
@@ -51,13 +52,9 @@ contract MockSwapRouter is ISwapRouter {
     address to,
     uint256 /*deadline*/
   ) external returns (uint256[] memory amounts) {
+    amounts = getAmountsOut(amountIn, path);
     IERC20Upgradeable(path[0]).safeTransferFrom(msg.sender, address(this), amountIn);
     IERC20Upgradeable(path[path.length - 1]).safeTransfer(to, amountIn);
-
-    amounts = new uint256[](2);
-    amounts[0] = amountIn;
-    amounts[1] = amountIn;
-    return amounts;
   }
 
   function swapTokensForExactTokens(
@@ -67,12 +64,24 @@ contract MockSwapRouter is ISwapRouter {
     address to,
     uint256 /*deadline*/
   ) external returns (uint256[] memory amounts) {
+    amounts = getAmountsIn(amountOut, path);
     IERC20Upgradeable(path[0]).safeTransferFrom(msg.sender, address(this), amountOut);
     IERC20Upgradeable(path[path.length - 1]).safeTransfer(to, amountOut);
+  }
 
-    amounts = new uint256[](2);
-    amounts[0] = amountOut;
-    amounts[1] = amountOut;
+  function getAmountsIn(uint256 amountOut, address[] memory path) public pure returns (uint256[] memory amounts) {
+    amounts = new uint256[](path.length);
+    for (uint256 i = 0; i < path.length; i++) {
+      amounts[i] = amountOut;
+    }
+    return amounts;
+  }
+
+  function getAmountsOut(uint256 amountIn, address[] memory path) public pure returns (uint256[] memory amounts) {
+    amounts = new uint256[](path.length);
+    for (uint256 i = 0; i < path.length; i++) {
+      amounts[i] = amountIn;
+    }
     return amounts;
   }
 }

--- a/test/integrations/protocol/RevenueTreasury.test.ts
+++ b/test/integrations/protocol/RevenueTreasury.test.ts
@@ -257,14 +257,20 @@ describe("RevenueTreasury", () => {
     });
 
     describe("when as owner set reinvest paths with length less than 2", async () => {
-      it("should revert", async () => {
+      it("should work unless token does not match grassHouse token", async () => {
         await expect(treasury.setRewardPath([alpaca.address])).to.be.revertedWith(
-          "RevenueTreasury_InvalidSwapPathLength()"
+          "RevenueTreasury_TokenMismatch()"
         );
+
+        await treasury.setToken(alpaca.address);
+
+        await expect(treasury.setRewardPath([alpaca.address]))
+          .to.emit(treasury, "LogSetRewardPath")
+          .withArgs(deployerAddress, [alpaca.address]);
       });
     });
 
-    describe("when as owner set reinvest paths but not start with alpaca token", async () => {
+    describe("when as owner set reinvest paths but not start with token", async () => {
       it("should revert", async () => {
         await expect(
           treasury.setRewardPath([alpaca.address, usdt.address])
@@ -289,14 +295,20 @@ describe("RevenueTreasury", () => {
     });
 
     describe("when as owner set reinvest paths with length less than 2", async () => {
-      it("should revert", async () => {
-        await expect(treasury.setVaultSwapPath([alpaca.address])).to.be.revertedWith(
-          "RevenueTreasury_InvalidSwapPathLength()"
+      it("should work unless token does not match vault token", async () => {
+        await expect(treasury.setVaultSwapPath([usdt.address])).to.be.revertedWith(
+          "RevenueTreasury_TokenMismatch()"
         );
+
+        await treasury.setToken(usdt.address);
+
+        await expect(treasury.setVaultSwapPath([usdt.address]))
+          .to.emit(treasury, "LogSetVaultSwapPath")
+          .withArgs(deployerAddress, [usdt.address]);
       });
     });
 
-    describe("when as owner set reinvest paths but not start with alpaca token", async () => {
+    describe("when as owner set reinvest paths but not start with token", async () => {
       it("should revert", async () => {
         await expect(
           treasury.setVaultSwapPath([alpaca.address, usdt.address])

--- a/test/integrations/protocol/RevenueTreasury.test.ts
+++ b/test/integrations/protocol/RevenueTreasury.test.ts
@@ -337,7 +337,9 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("50"), ethers.utils.parseEther("50"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("50"))
+          .to.emit(treasury, "LogSettleBadDebt")
+          .withArgs(deployerAddress, ethers.utils.parseEther("50"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
         expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("50"));
@@ -353,7 +355,9 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("100"), ethers.utils.parseEther("0"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("0"))
+          .to.emit(treasury, "LogSettleBadDebt")
+          .withArgs(deployerAddress, ethers.utils.parseEther("100"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
         expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("100"));
@@ -369,7 +373,9 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("0"), ethers.utils.parseEther("100"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("100"))
+          .to.emit(treasury, "LogSettleBadDebt")
+          .withArgs(deployerAddress, ethers.utils.parseEther("0"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
         expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("0"));
@@ -384,7 +390,9 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("30000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("20000"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("20000"))
+          .to.emit(treasury, "LogSettleBadDebt")
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
         expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
@@ -400,7 +408,9 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("20000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"))
+          .to.emit(treasury, "LogSettleBadDebt")
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
         expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
@@ -411,7 +421,7 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("5000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("0"), ethers.utils.parseEther("5000"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("5000"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
         expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
@@ -427,7 +437,9 @@ describe("RevenueTreasury", () => {
         await usdt.transfer(treasury.address, ethers.utils.parseEther("20000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"))
+          .to.emit(treasury, "LogSettleBadDebt")
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"));
 
         expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("10000"));
@@ -442,7 +454,9 @@ describe("RevenueTreasury", () => {
         await alpaca.transfer(treasury.address, ethers.utils.parseEther("20000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"))
+          .to.emit(treasury, "LogSettleBadDebt")
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"));
 
         expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("10000"));

--- a/test/integrations/protocol/RevenueTreasury.test.ts
+++ b/test/integrations/protocol/RevenueTreasury.test.ts
@@ -24,6 +24,7 @@ describe("RevenueTreasury", () => {
   // Contact Instance
   let alpaca: MockERC20;
   let usdt: MockERC20;
+  let busd: MockERC20;
 
   let treasury: RevenueTreasury;
   let grassHouse: MockGrassHouse;
@@ -55,7 +56,7 @@ describe("RevenueTreasury", () => {
     // Deploy ALPACA
 
     /// Setup token stuffs
-    [alpaca, usdt] = await deployHelper.deployBEP20([
+    [alpaca, usdt, busd] = await deployHelper.deployBEP20([
       {
         name: "ALPACA",
         symbol: "ALPACA",
@@ -74,6 +75,15 @@ describe("RevenueTreasury", () => {
           { address: aliceAddress, amount: ethers.utils.parseEther("10000000000000") },
         ],
       },
+      {
+        name: "BUSD",
+        symbol: "BUSD",
+        decimals: "18",
+        holders: [
+          { address: deployerAddress, amount: ethers.utils.parseEther("10000000000000") },
+          { address: aliceAddress, amount: ethers.utils.parseEther("10000000000000") },
+        ],
+      },
     ]);
 
     // Deploy GrassHouse
@@ -82,9 +92,10 @@ describe("RevenueTreasury", () => {
 
     // Deploy router
     const MockSwapRouter = (await ethers.getContractFactory("MockSwapRouter", deployer)) as MockSwapRouter__factory;
-    router = await MockSwapRouter.deploy(usdt.address, alpaca.address);
+    router = await MockSwapRouter.deploy();
 
     usdt.transfer(router.address, ethers.utils.parseEther("100000"));
+    busd.transfer(router.address, ethers.utils.parseEther("100000"));
     alpaca.transfer(router.address, ethers.utils.parseEther("100000"));
 
     // Deploy Vault
@@ -96,7 +107,7 @@ describe("RevenueTreasury", () => {
     const remaining = ethers.utils.parseEther("10000");
     const RevenueTreasury = (await ethers.getContractFactory("RevenueTreasury", deployer)) as RevenueTreasury__factory;
     const revenueTreasury = (await upgrades.deployProxy(RevenueTreasury, [
-      usdt.address,
+      busd.address,
       grassHouse.address,
       vault.address,
       router.address,
@@ -104,6 +115,7 @@ describe("RevenueTreasury", () => {
       splitBps
     ])) as RevenueTreasury;
     treasury = await revenueTreasury.deployed();
+    treasury.setRewardPath([busd.address, alpaca.address]);
 
     // MINT
     await alpaca.mint(deployerAddress, ethers.utils.parseEther("8888888"));
@@ -129,7 +141,7 @@ describe("RevenueTreasury", () => {
         expect(await treasury.owner()).to.be.eq(deployerAddress);
         expect(await treasury.grassHouse()).to.be.eq(grassHouse.address);
         expect(await treasury.grasshouseToken()).to.be.eq(alpaca.address);
-        expect(await treasury.token()).to.be.eq(usdt.address);
+        expect(await treasury.token()).to.be.eq(busd.address);
         expect(await treasury.remaining()).to.be.eq(ethers.utils.parseEther("10000"));
       });
     });
@@ -161,21 +173,6 @@ describe("RevenueTreasury", () => {
         ])).to.be.revertedWith("Address: low-level delegate call failed");
       });
     });
-
-    describe("if the address is not vault", async () => {
-      it("should revert", async () => {
-        const RevenueTreasury = (await ethers.getContractFactory("RevenueTreasury", deployer)) as RevenueTreasury__factory;
-        await expect(upgrades.deployProxy(RevenueTreasury, [
-          usdt.address,
-          grassHouse.address,
-          router.address, // should be vault
-          router.address,
-          ethers.utils.parseEther("10000"),
-          5000
-        ])).to.be.revertedWith("Address: low-level delegate call failed");
-      });
-    });
-
 
     describe("if the split bps is exceed 10000", async () => {
       it("should revert", async () => {
@@ -221,7 +218,7 @@ describe("RevenueTreasury", () => {
       it("should work", async () => {
         // Deploy GrassHouse
         const MockSwapRouter = (await ethers.getContractFactory("MockSwapRouter", deployer)) as MockSwapRouter__factory;
-        const newRouter = await MockSwapRouter.deploy(usdt.address, alpaca.address);
+        const newRouter = await MockSwapRouter.deploy();
 
         await treasury.setRouter(newRouter.address);
 
@@ -241,25 +238,25 @@ describe("RevenueTreasury", () => {
   });
 
   context("#setRewardPath", async () => {
-    describe("when as owner set reinvest paths and start with alpaca token", async () => {
+    describe("when as owner set reinvest paths and start with busd token", async () => {
       it("should work", async () => {
-        await expect(treasury.setRewardPath([usdt.address, alpaca.address]))
+        await expect(treasury.setRewardPath([busd.address, alpaca.address]))
           .to.emit(treasury, "LogSetRewardPath")
-          .withArgs(deployerAddress, [usdt.address, alpaca.address]);
+          .withArgs(deployerAddress, [busd.address, alpaca.address]);
 
-        const randomAddress = "0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56";
+
         await expect(
-          treasury.setRewardPath([usdt.address, randomAddress, alpaca.address])
+          treasury.setRewardPath([busd.address, usdt.address, alpaca.address])
         )
           .to.emit(treasury, "LogSetRewardPath")
-          .withArgs(deployerAddress, [usdt.address, randomAddress, alpaca.address]);
+          .withArgs(deployerAddress, [busd.address, usdt.address, alpaca.address]);
       });
     });
 
     describe("when as owner set reinvest paths with length less than 2", async () => {
       it("should revert", async () => {
         await expect(treasury.setRewardPath([alpaca.address])).to.be.revertedWith(
-          "RevenueTreasury_InvalidRewardPathLength()"
+          "RevenueTreasury_InvalidSwapPathLength()"
         );
       });
     });
@@ -268,7 +265,40 @@ describe("RevenueTreasury", () => {
       it("should revert", async () => {
         await expect(
           treasury.setRewardPath([alpaca.address, usdt.address])
-        ).to.be.revertedWith("RevenueTreasury_InvalidRewardPath()");
+        ).to.be.revertedWith("RevenueTreasury_InvalidSwapPath()");
+      });
+    });
+  });
+
+
+  context("#setVaultSwapPath", async () => {
+    describe("when as owner set reinvest paths and start with busd token", async () => {
+      it("should work", async () => {
+        await expect(treasury.setVaultSwapPath([busd.address, usdt.address]))
+          .to.emit(treasury, "LogSetVaultSwapPath")
+          .withArgs(deployerAddress, [busd.address, usdt.address]);
+
+        await expect(
+          treasury.setVaultSwapPath([busd.address, alpaca.address, usdt.address])
+        )
+          .to.emit(treasury, "LogSetVaultSwapPath")
+          .withArgs(deployerAddress, [busd.address, alpaca.address, usdt.address]);
+      });
+    });
+
+    describe("when as owner set reinvest paths with length less than 2", async () => {
+      it("should revert", async () => {
+        await expect(treasury.setVaultSwapPath([alpaca.address])).to.be.revertedWith(
+          "RevenueTreasury_InvalidSwapPathLength()"
+        );
+      });
+    });
+
+    describe("when as owner set reinvest paths but not start with alpaca token", async () => {
+      it("should revert", async () => {
+        await expect(
+          treasury.setVaultSwapPath([alpaca.address, usdt.address])
+        ).to.be.revertedWith("RevenueTreasury_InvalidSwapPath()");
       });
     });
   });
@@ -298,15 +328,15 @@ describe("RevenueTreasury", () => {
   context("#feedGrassHouse", async () => {
     describe("If amount to cover < remaining", async () => {
       it("should split token into 50:50", async () => {
-        await usdt.transfer(treasury.address, ethers.utils.parseEther("100"));
+        await busd.transfer(treasury.address, ethers.utils.parseEther("100"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
           .withArgs(deployerAddress, ethers.utils.parseEther("50"), ethers.utils.parseEther("50"), ethers.utils.parseEther("50"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("50"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
+        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("50"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("50"));
       });
     });
@@ -314,15 +344,15 @@ describe("RevenueTreasury", () => {
     describe("If amount to cover < remaining and split bps = 100", async () => {
       it("should split transfer all and feed none", async () => {
         await treasury.setSplitBps(10000);
-        await usdt.transfer(treasury.address, ethers.utils.parseEther("100"));
+        await busd.transfer(treasury.address, ethers.utils.parseEther("100"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
           .withArgs(deployerAddress, ethers.utils.parseEther("100"), ethers.utils.parseEther("0"), ethers.utils.parseEther("0"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("100"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
+        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("100"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("0"));
       });
     });
@@ -330,30 +360,30 @@ describe("RevenueTreasury", () => {
     describe("If amount to cover < remaining and split bps = 0", async () => {
       it("should split swapp all and transfer non", async () => {
         await treasury.setSplitBps(0);
-        await usdt.transfer(treasury.address, ethers.utils.parseEther("100"));
+        await busd.transfer(treasury.address, ethers.utils.parseEther("100"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
           .withArgs(deployerAddress, ethers.utils.parseEther("0"), ethers.utils.parseEther("100"), ethers.utils.parseEther("100"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("0"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
+        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("0"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("100"));
       });
     });
 
     describe("If amount to cover > remaining", async () => {
       it("should transfer only to cover bad debt", async () => {
-        await usdt.transfer(treasury.address, ethers.utils.parseEther("30000"));
+        await busd.transfer(treasury.address, ethers.utils.parseEther("30000"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("30000"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("30000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
           .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("20000"), ethers.utils.parseEther("20000"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
+        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("20000"));
       });
     });
@@ -361,26 +391,26 @@ describe("RevenueTreasury", () => {
     describe("If remaining = 0", async () => {
       it("should swap all to reward and feed grasshouse", async () => {
         // Cover all remaining first
-        await usdt.transfer(treasury.address, ethers.utils.parseEther("20000"));
+        await busd.transfer(treasury.address, ethers.utils.parseEther("20000"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("20000"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("20000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
           .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
+        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("10000"));
 
         // Another round of revenue distribution
-        await usdt.transfer(treasury.address, ethers.utils.parseEther("5000"));
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("5000"));
+        await busd.transfer(treasury.address, ethers.utils.parseEther("5000"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("5000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
           .withArgs(deployerAddress, ethers.utils.parseEther("0"), ethers.utils.parseEther("5000"), ethers.utils.parseEther("5000"));
 
-        expect(await usdt.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
+        expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
+        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("15000"));
       });
     });

--- a/test/integrations/protocol/RevenueTreasury.test.ts
+++ b/test/integrations/protocol/RevenueTreasury.test.ts
@@ -116,6 +116,7 @@ describe("RevenueTreasury", () => {
     ])) as RevenueTreasury;
     treasury = await revenueTreasury.deployed();
     treasury.setRewardPath([busd.address, alpaca.address]);
+    treasury.setVaultSwapPath([busd.address, usdt.address]);
 
     // MINT
     await alpaca.mint(deployerAddress, ethers.utils.parseEther("8888888"));
@@ -201,11 +202,13 @@ describe("RevenueTreasury", () => {
         expect(await treasury.grasshouseToken()).to.be.eq(usdt.address);
       });
     });
+
     describe("if the address is not grasshouse", async () => {
       it("should revert", async () => {
         await expect(treasury.setGrassHouse(usdt.address)).to.be.revertedWith("Transaction reverted: function selector was not recognized and there's no fallback function");
       });
     });
+
     describe("if the caller is not owner", async () => {
       it("should revert", async () => {
         await expect(treasuryAsAlice.setGrassHouse(usdt.address)).to.be.revertedWith("'Ownable: caller is not the owner");
@@ -238,7 +241,7 @@ describe("RevenueTreasury", () => {
   });
 
   context("#setRewardPath", async () => {
-    describe("when as owner set reinvest paths and start with busd token", async () => {
+    describe("when owner set reinvest paths and start with busd token", async () => {
       it("should work", async () => {
         await expect(treasury.setRewardPath([busd.address, alpaca.address]))
           .to.emit(treasury, "LogSetRewardPath")
@@ -270,9 +273,8 @@ describe("RevenueTreasury", () => {
     });
   });
 
-
   context("#setVaultSwapPath", async () => {
-    describe("when as owner set reinvest paths and start with busd token", async () => {
+    describe("when owner set reinvest paths and start with busd token", async () => {
       it("should work", async () => {
         await expect(treasury.setVaultSwapPath([busd.address, usdt.address]))
           .to.emit(treasury, "LogSetVaultSwapPath")
@@ -311,6 +313,7 @@ describe("RevenueTreasury", () => {
           .withArgs(deployerAddress, 5000, 50);
       });
     });
+
     describe("if bps > 10000", async () => {
       it("should revert", async () => {
         await expect(treasury.setSplitBps(10001)).to.be.revertedWith(
@@ -318,6 +321,7 @@ describe("RevenueTreasury", () => {
         );
       });
     });
+
     describe("if the caller is not owner", async () => {
       it("should revert", async () => {
         await expect(treasuryAsAlice.setSplitBps(10001)).to.be.revertedWith("'Ownable: caller is not the owner");
@@ -333,10 +337,10 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("50"), ethers.utils.parseEther("50"), ethers.utils.parseEther("50"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("50"), ethers.utils.parseEther("50"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("50"));
+        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("50"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("50"));
       });
     });
@@ -349,10 +353,10 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("100"), ethers.utils.parseEther("0"), ethers.utils.parseEther("0"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("100"), ethers.utils.parseEther("0"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("100"));
+        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("100"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("0"));
       });
     });
@@ -365,10 +369,10 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("100"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("0"), ethers.utils.parseEther("100"), ethers.utils.parseEther("100"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("0"), ethers.utils.parseEther("100"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("0"));
+        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("0"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("100"));
       });
     });
@@ -380,10 +384,10 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("30000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("20000"), ethers.utils.parseEther("20000"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("20000"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
+        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("20000"));
       });
     });
@@ -396,10 +400,10 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("20000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
+        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("10000"));
 
         // Another round of revenue distribution
@@ -407,11 +411,80 @@ describe("RevenueTreasury", () => {
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("5000"));
 
         expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
-          .withArgs(deployerAddress, ethers.utils.parseEther("0"), ethers.utils.parseEther("5000"), ethers.utils.parseEther("5000"));
+          .withArgs(deployerAddress, ethers.utils.parseEther("0"), ethers.utils.parseEther("5000"));
 
         expect(await busd.balanceOf(treasury.address)).to.be.eq(ethers.utils.parseEther("0"));
-        expect(await busd.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
+        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
         expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("15000"));
+      });
+    });
+
+    describe("In case there's no need for vault swap", async () => {
+      it("should work", async () => {
+        await treasury.setToken(usdt.address);
+        await treasury.setRewardPath([usdt.address, alpaca.address]);
+        await treasury.setVaultSwapPath([]);
+        await usdt.transfer(treasury.address, ethers.utils.parseEther("20000"));
+
+        expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"));
+
+        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
+        expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("10000"));
+      });
+    });
+
+    describe("In case there's no need for reward swap", async () => {
+      it("should work", async () => {
+        await treasury.setToken(alpaca.address);
+        await treasury.setRewardPath([]);
+        await treasury.setVaultSwapPath([alpaca.address, usdt.address]);
+        await alpaca.transfer(treasury.address, ethers.utils.parseEther("20000"));
+
+        expect(treasury.feedGrassHouse()).to.emit(treasury, "LogFeedGrassHouse")
+          .withArgs(deployerAddress, ethers.utils.parseEther("10000"), ethers.utils.parseEther("10000"));
+
+        expect(await usdt.balanceOf(vault.address)).to.be.eq(ethers.utils.parseEther("10000"));
+        expect(await alpaca.balanceOf(grassHouse.address)).to.be.eq(ethers.utils.parseEther("10000"));
+      });
+    });
+
+    describe("If token has been changed but swap path hasn't been changed", async () => {
+      it("should revert", async () => {
+        await treasury.setToken(usdt.address);
+        await usdt.transfer(treasury.address, ethers.utils.parseEther("20000"));
+
+        expect(treasury.feedGrassHouse()).to.be.revertedWith("RevenueTreasury_InvalidSwapPath()");
+
+      });
+    });
+
+    describe("If vault has been changed but swap path hasn't been changed", async () => {
+      it("should revert", async () => {
+        // Deploy Vault
+        const MockVault = (await ethers.getContractFactory("MockVault", deployer)) as MockVault__factory;
+        const alpacaVault = await MockVault.deploy(alpaca.address);
+
+        await treasury.setVault(alpacaVault.address);
+        await usdt.transfer(treasury.address, ethers.utils.parseEther("20000"));
+
+        expect(treasury.feedGrassHouse()).to.be.revertedWith("RevenueTreasury_InvalidSwapPath()");
+
+      });
+    });
+
+    describe("If grassHouse has been changed but swap path hasn't been changed", async () => {
+      it("should revert", async () => {
+        // Deploy GrassHouse
+        const MockGrassHouse = (await ethers.getContractFactory("MockGrassHouse", deployer)) as MockGrassHouse__factory;
+        const usdtGrassHouse = await MockGrassHouse.deploy(usdt.address);
+
+
+        await treasury.setGrassHouse(usdtGrassHouse.address);
+        await usdt.transfer(treasury.address, ethers.utils.parseEther("20000"));
+
+        expect(treasury.feedGrassHouse()).to.be.revertedWith("RevenueTreasury_InvalidSwapPath()");
+
       });
     });
   });


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
Add more flexibility and reusability for Revenue Treasury

## Why?
Previous version of the contract would need to be redeployed as
- There is not swap to transfer to vault
- There is no setter to update token, vault, remaining

## ChangeLogs:
- add setters
- add swap functionality before transfer to vault


### Link to story (if available)
<!--- Add story URL here -->
