### PR TITLE
[main][feat] Support AIP4.2

### DIFF
--- a/contracts/6/protocol/VaultAip42.sol
+++ b/contracts/6/protocol/VaultAip42.sol
@@ -397,18 +397,18 @@ contract VaultAip42 is IVault, ERC20UpgradeSafe, ReentrancyGuardUpgradeSafe, Own
   /// @dev Only the deployer can call this function.
   /// @param id The position ID to be killed.
   function forceClose(uint256 id, bytes calldata data) external accrue(0) nonReentrant {
-    // 1. Verify that the position is eligible for liquidation.
+    // 1. Only deployer is allowed to execute this function
     require(msg.sender == 0xC44f82b07Ab3E691F826951a6E335E1bC1bB0B51, "!D");
     Position storage pos = positions[id];
-    // 2. Distribute ALPACAs in FairLaunch to owner
+    // 2. Distribute ALPACAs in FairLaunch to the position owner
     _fairLaunchWithdraw(id);
     uint256 debt = _removeDebt(id);
-    // 3. Perform liquidation and compute the amount of token received.
+    // 3. Perform force close and compute the amount of token received.
     uint256 beforeToken = SafeToken.myBalance(token);
     IWorker(pos.worker).work(id, pos.owner, debt, data);
     uint256 back = SafeToken.myBalance(token).sub(beforeToken);
 
-    // 4. Clear position debt and return funds to liquidator and position owner.
+    // 4. Clear position debt and return funds to the position owner.
     uint256 left = back > debt ? back - debt : 0;
     if (left > 0) {
       _safeUnwrap(pos.owner, left);

--- a/contracts/6/protocol/VaultAip42.sol
+++ b/contracts/6/protocol/VaultAip42.sol
@@ -1,0 +1,510 @@
+// SPDX-License-Identifier: MIT
+/**
+  ∩~~~~∩ 
+  ξ ･×･ ξ 
+  ξ　~　ξ 
+  ξ　　 ξ 
+  ξ　　 “~～~～〇 
+  ξ　　　　　　 ξ 
+  ξ ξ ξ~～~ξ ξ ξ 
+　 ξ_ξξ_ξ　ξ_ξξ_ξ
+Alpaca Fin Corporation
+*/
+
+pragma solidity 0.6.6;
+
+import "@openzeppelin/contracts-ethereum-package/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/math/Math.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts-ethereum-package/contracts/Initializable.sol";
+
+import "./interfaces/IDebtToken.sol";
+import "./interfaces/IVaultConfig.sol";
+import "./interfaces/IWorker.sol";
+import "./interfaces/IVault.sol";
+import "../token/interfaces/IFairLaunch.sol";
+import "../utils/SafeToken.sol";
+import "./interfaces/IWETH.sol";
+import "./interfaces/IWNativeRelayer.sol";
+
+contract VaultAip42 is IVault, ERC20UpgradeSafe, ReentrancyGuardUpgradeSafe, OwnableUpgradeSafe {
+  /// @notice Libraries
+  using SafeToken for address;
+  using SafeMath for uint256;
+
+  /// @notice Events
+  event AddDebt(uint256 indexed id, uint256 debtShare);
+  event RemoveDebt(uint256 indexed id, uint256 debtShare);
+  event Work(uint256 indexed id, uint256 loan);
+  event Kill(
+    uint256 indexed id,
+    address indexed killer,
+    address owner,
+    uint256 posVal,
+    uint256 debt,
+    uint256 prize,
+    uint256 left
+  );
+  event AddCollateral(uint256 indexed id, uint256 amount, uint256 healthBefore, uint256 healthAfter);
+
+  /// @dev Flags for manage execution scope
+  uint256 private constant _NOT_ENTERED = 1;
+  uint256 private constant _ENTERED = 2;
+  uint256 private constant _NO_ID = uint256(-1);
+  address private constant _NO_ADDRESS = address(1);
+
+  /// @dev Temporay variables to manage execution scope
+  uint256 public _IN_EXEC_LOCK;
+  uint256 public POSITION_ID;
+  address public STRATEGY;
+
+  /// @dev Attributes for Vault
+  /// token - address of the token to be deposited in this pool
+  /// name - name of the ibERC20
+  /// symbol - symbol of ibERC20
+  /// decimals - decimals of ibERC20, this depends on the decimal of the token
+  /// debtToken - just a simple ERC20 token for staking with FairLaunch
+  address public override token;
+  address public debtToken;
+
+  struct Position {
+    address worker;
+    address owner;
+    uint256 debtShare;
+  }
+
+  IVaultConfig public config;
+  mapping(uint256 => Position) public positions;
+  uint256 public nextPositionID;
+  uint256 public fairLaunchPoolId;
+
+  uint256 public vaultDebtShare;
+  uint256 public vaultDebtVal;
+  uint256 public lastAccrueTime;
+  uint256 public reservePool;
+
+  /// @dev Require that the caller must be an EOA account if not whitelisted.
+  modifier onlyEOAorWhitelisted() {
+    if (!config.whitelistedCallers(msg.sender)) {
+      require(msg.sender == tx.origin, "not eoa");
+    }
+    _;
+  }
+
+  /// @dev Require that the caller must be an EOA account if not whitelisted.
+  modifier onlyWhitelistedLiqudators() {
+    require(config.whitelistedLiquidators(msg.sender), "!whitelisted liquidator");
+    _;
+  }
+
+  /// @dev Get token from msg.sender
+  modifier transferTokenToVault(uint256 value) {
+    if (msg.value != 0) {
+      require(token == config.getWrappedNativeAddr(), "baseToken is not wNative");
+      require(value == msg.value, "value != msg.value");
+      IWETH(config.getWrappedNativeAddr()).deposit{ value: msg.value }();
+    } else {
+      SafeToken.safeTransferFrom(token, msg.sender, address(this), value);
+    }
+    _;
+  }
+
+  /// @dev Ensure that the function is called with the execution scope
+  modifier inExec() {
+    require(POSITION_ID != _NO_ID, "not within execution scope");
+    require(STRATEGY == msg.sender, "not from the strategy");
+    require(_IN_EXEC_LOCK == _NOT_ENTERED, "in exec lock");
+    _IN_EXEC_LOCK = _ENTERED;
+    _;
+    _IN_EXEC_LOCK = _NOT_ENTERED;
+  }
+
+  /// @dev Add more debt to the bank debt pool.
+  modifier accrue(uint256 value) {
+    if (now > lastAccrueTime) {
+      uint256 interest = pendingInterest(value);
+      uint256 toReserve = interest.mul(config.getReservePoolBps()).div(10000);
+      reservePool = reservePool.add(toReserve);
+      vaultDebtVal = vaultDebtVal.add(interest);
+      lastAccrueTime = now;
+    }
+    _;
+  }
+
+  function initialize(
+    IVaultConfig _config,
+    address _token,
+    string calldata _name,
+    string calldata _symbol,
+    uint8 _decimals,
+    address _debtToken
+  ) external initializer {
+    OwnableUpgradeSafe.__Ownable_init();
+    ReentrancyGuardUpgradeSafe.__ReentrancyGuard_init();
+    ERC20UpgradeSafe.__ERC20_init(_name, _symbol);
+    _setupDecimals(_decimals);
+
+    nextPositionID = 1;
+    config = _config;
+    lastAccrueTime = now;
+    token = _token;
+
+    fairLaunchPoolId = uint256(-1);
+
+    debtToken = _debtToken;
+
+    SafeToken.safeApprove(debtToken, config.getFairLaunchAddr(), uint256(-1));
+
+    // free-up execution scope
+    _IN_EXEC_LOCK = _NOT_ENTERED;
+    POSITION_ID = _NO_ID;
+    STRATEGY = _NO_ADDRESS;
+  }
+
+  /// @dev Return the pending interest that will be accrued in the next call.
+  /// @param value Balance value to subtract off address(this).balance when called from payable functions.
+  function pendingInterest(uint256 value) public view returns (uint256) {
+    if (now > lastAccrueTime) {
+      uint256 timePast = now.sub(lastAccrueTime);
+      uint256 balance = SafeToken.myBalance(token).sub(value);
+      uint256 ratePerSec = config.getInterestRate(vaultDebtVal, balance);
+      return ratePerSec.mul(vaultDebtVal).mul(timePast).div(1e18);
+    } else {
+      return 0;
+    }
+  }
+
+  /// @dev Return the Token debt value given the debt share. Be careful of unaccrued interests.
+  /// @param debtShare The debt share to be converted.
+  function debtShareToVal(uint256 debtShare) public view returns (uint256) {
+    if (vaultDebtShare == 0) return debtShare; // When there's no share, 1 share = 1 val.
+    return debtShare.mul(vaultDebtVal).div(vaultDebtShare);
+  }
+
+  /// @dev Return the debt share for the given debt value. Be careful of unaccrued interests.
+  /// @param debtVal The debt value to be converted.
+  function debtValToShare(uint256 debtVal) public view returns (uint256) {
+    if (vaultDebtShare == 0) return debtVal; // When there's no share, 1 share = 1 val.
+    return debtVal.mul(vaultDebtShare).div(vaultDebtVal);
+  }
+
+  /// @dev Return Token value and debt of the given position. Be careful of unaccrued interests.
+  /// @param id The position ID to query.
+  function positionInfo(uint256 id) external view returns (uint256, uint256) {
+    Position storage pos = positions[id];
+    return (IWorker(pos.worker).health(id), debtShareToVal(pos.debtShare));
+  }
+
+  /// @dev Return the total token entitled to the token holders. Be careful of unaccrued interests.
+  function totalToken() public view override returns (uint256) {
+    return SafeToken.myBalance(token).add(vaultDebtVal).sub(reservePool);
+  }
+
+  /// @dev Add more token to the lending pool. Hope to get some good returns.
+  function deposit(uint256 amountToken)
+    external
+    payable
+    override
+    transferTokenToVault(amountToken)
+    accrue(amountToken)
+    nonReentrant
+  {
+    _deposit(amountToken);
+  }
+
+  function _deposit(uint256 amountToken) internal {
+    uint256 total = totalToken().sub(amountToken);
+    uint256 share = total == 0 ? amountToken : amountToken.mul(totalSupply()).div(total);
+    _mint(msg.sender, share);
+    require(totalSupply() > 10**(uint256(decimals()).sub(1)), "no tiny shares");
+  }
+
+  /// @dev Withdraw token from the lending and burning ibToken.
+  function withdraw(uint256 share) external override accrue(0) nonReentrant {
+    uint256 amount = share.mul(totalToken()).div(totalSupply());
+    _burn(msg.sender, share);
+    _safeUnwrap(msg.sender, amount);
+    require(totalSupply() > 10**(uint256(decimals()).sub(1)), "no tiny shares");
+  }
+
+  /// @dev Request Funds from user through Vault
+  function requestFunds(address targetedToken, uint256 amount) external override inExec {
+    SafeToken.safeTransferFrom(targetedToken, positions[POSITION_ID].owner, msg.sender, amount);
+  }
+
+  /// @dev Mint & deposit debtToken on behalf of farmers
+  /// @param id The ID of the position
+  /// @param amount The amount of debt that the position holds
+  function _fairLaunchDeposit(uint256 id, uint256 amount) internal {
+    if (amount > 0) {
+      IDebtToken(debtToken).mint(address(this), amount);
+      IFairLaunch(config.getFairLaunchAddr()).deposit(positions[id].owner, fairLaunchPoolId, amount);
+    }
+  }
+
+  /// @dev Withdraw & burn debtToken on behalf of farmers
+  /// @param id The ID of the position
+  function _fairLaunchWithdraw(uint256 id) internal {
+    if (positions[id].debtShare > 0) {
+      // Note: Do this way because we don't want to fail open, close, or kill position
+      // if cannot withdraw from FairLaunch somehow. 0xb5c5f672 is a signature of withdraw(address,uint256,uint256)
+      (bool success, ) = config.getFairLaunchAddr().call(
+        abi.encodeWithSelector(0xb5c5f672, positions[id].owner, fairLaunchPoolId, positions[id].debtShare)
+      );
+      if (success) IDebtToken(debtToken).burn(address(this), positions[id].debtShare);
+    }
+  }
+
+  /// @dev Transfer to "to". Automatically unwrap if BTOKEN is WBNB
+  /// @param to The address of the receiver
+  /// @param amount The amount to be withdrawn
+  function _safeUnwrap(address to, uint256 amount) internal {
+    if (token == config.getWrappedNativeAddr()) {
+      SafeToken.safeTransfer(token, config.getWNativeRelayer(), amount);
+      IWNativeRelayer(uint160(config.getWNativeRelayer())).withdraw(amount);
+      SafeToken.safeTransferETH(to, amount);
+    } else {
+      SafeToken.safeTransfer(token, to, amount);
+    }
+  }
+
+  /// @dev addCollateral to the given position.
+  /// @param id The ID of the position to add collaterals.
+  /// @param amount The amount of BTOKEN to be added to the position
+  /// @param goRogue If on skip worker stability check, else only check reserve consistency.
+  /// @param data The calldata to pass along to the worker for more working context.
+  function addCollateral(
+    uint256 id,
+    uint256 amount,
+    bool goRogue,
+    bytes calldata data
+  ) external payable onlyEOAorWhitelisted transferTokenToVault(amount) accrue(amount) nonReentrant {
+    require(fairLaunchPoolId != uint256(-1), "poolId not set");
+    require(id != 0, "no id 0");
+
+    // 1. Load position from state & sanity check
+    Position storage pos = positions[id];
+    address worker = pos.worker;
+    uint256 healthBefore = IWorker(worker).health(id);
+    require(id < nextPositionID, "bad position id");
+    require(pos.owner == msg.sender, "!position owner");
+    require(healthBefore != 0, "!active position");
+    // 2. Book execution scope variables. Check if the given strategy is known add strat.
+    POSITION_ID = id;
+    (STRATEGY, ) = abi.decode(data, (address, bytes));
+    require(config.approvedAddStrategies(STRATEGY), "!approved strat");
+    // 3. If not goRouge then check worker stability, else only check reserve consistency.
+    if (!goRogue) require(config.isWorkerStable(worker), "worker !stable");
+    else require(config.isWorkerReserveConsistent(worker), "reserve !consistent");
+    // 4. Getting required info.
+    uint256 debt = debtShareToVal(pos.debtShare);
+    // 5. Perform add collateral according to the strategy.
+    uint256 beforeBEP20 = SafeToken.myBalance(token).sub(amount);
+    SafeToken.safeTransfer(token, worker, amount);
+    IWorker(worker).work(id, msg.sender, debt, data);
+    uint256 healthAfter = IWorker(worker).health(id);
+    uint256 back = SafeToken.myBalance(token).sub(beforeBEP20);
+    // 6. Sanity check states after perform add collaterals
+    // - if not goRouge then check worker stability else only check reserve consistency.
+    // - back must be 0 as it is adding collateral only. No BTOKEN needed to be returned.
+    // - healthAfter must more than before.
+    // - debt ratio must below kill factor - 1%
+    if (!goRogue) require(config.isWorkerStable(worker), "worker !stable");
+    else require(config.isWorkerReserveConsistent(worker), "reserve !consistent");
+    require(back == 0, "back !0");
+    require(healthAfter > healthBefore, "health !increase");
+    uint256 killFactor = config.rawKillFactor(pos.worker, debt);
+    require(debt.mul(10000) <= healthAfter.mul(killFactor.sub(100)), "debtRatio > killFactor margin");
+    // 7. Release execution scope
+    POSITION_ID = _NO_ID;
+    STRATEGY = _NO_ADDRESS;
+    // 8. Emit event
+    emit AddCollateral(id, amount, healthBefore, healthAfter);
+  }
+
+  /// @dev Create a new farming position to unlock your yield farming potential.
+  /// @param id The ID of the position to unlock the earning. Use ZERO for new position.
+  /// @param worker The address of the authorized worker to work for this position.
+  /// @param principalAmount The anout of Token to supply by user.
+  /// @param borrowAmount The amount of Token to borrow from the pool.
+  /// @param maxReturn The max amount of Token to return to the pool.
+  /// @param data The calldata to pass along to the worker for more working context.
+  function work(
+    uint256 id,
+    address worker,
+    uint256 principalAmount,
+    uint256 borrowAmount,
+    uint256 maxReturn,
+    bytes calldata data
+  ) external payable onlyEOAorWhitelisted transferTokenToVault(principalAmount) accrue(principalAmount) nonReentrant {
+    require(fairLaunchPoolId != uint256(-1), "poolId not set");
+    // 1. Sanity check the input position, or add a new position of ID is 0.
+    Position storage pos;
+    if (id == 0) {
+      id = nextPositionID++;
+      pos = positions[id];
+      pos.worker = worker;
+      pos.owner = msg.sender;
+    } else {
+      pos = positions[id];
+      require(id < nextPositionID, "bad position id");
+      require(pos.worker == worker, "bad position worker");
+      require(pos.owner == msg.sender, "not position owner");
+      _fairLaunchWithdraw(id);
+    }
+    emit Work(id, borrowAmount);
+    // Update execution scope variables
+    POSITION_ID = id;
+    (STRATEGY, ) = abi.decode(data, (address, bytes));
+    // 2. Make sure the worker can accept more debt and remove the existing debt.
+    require(config.isWorker(worker), "not a worker");
+    require(borrowAmount == 0 || config.acceptDebt(worker), "worker not accept more debt");
+    uint256 debt = _removeDebt(id).add(borrowAmount);
+    // 3. Perform the actual work, using a new scope to avoid stack-too-deep errors.
+    uint256 back;
+    {
+      uint256 sendBEP20 = principalAmount.add(borrowAmount);
+      require(sendBEP20 <= SafeToken.myBalance(token), "insufficient funds in the vault");
+      uint256 beforeBEP20 = SafeToken.myBalance(token).sub(sendBEP20);
+      SafeToken.safeTransfer(token, worker, sendBEP20);
+      IWorker(worker).work(id, msg.sender, debt, data);
+      back = SafeToken.myBalance(token).sub(beforeBEP20);
+    }
+    // 4. Check and update position debt.
+    uint256 lessDebt = Math.min(debt, Math.min(back, maxReturn));
+    debt = debt.sub(lessDebt);
+    if (debt > 0) {
+      require(debt >= config.minDebtSize(), "too small debt size");
+      uint256 health = IWorker(worker).health(id);
+      uint256 workFactor = config.workFactor(worker, debt);
+      require(health.mul(workFactor) >= debt.mul(10000), "bad work factor");
+      _addDebt(id, debt);
+      _fairLaunchDeposit(id, pos.debtShare);
+    }
+    // 5. Release execution scope
+    POSITION_ID = _NO_ID;
+    STRATEGY = _NO_ADDRESS;
+    // 6. Return excess token back.
+    if (back > lessDebt) {
+      _safeUnwrap(msg.sender, back.sub(lessDebt));
+    }
+  }
+
+  /// @notice Force close the given position as per AIP4.2.
+  /// @dev Only the deployer can call this function.
+  /// @param id The position ID to be killed.
+  function forceClose(uint256 id, bytes calldata data) external accrue(0) nonReentrant {
+    // 1. Verify that the position is eligible for liquidation.
+    require(msg.sender == 0xC44f82b07Ab3E691F826951a6E335E1bC1bB0B51, "!D");
+    Position storage pos = positions[id];
+    // 2. Distribute ALPACAs in FairLaunch to owner
+    _fairLaunchWithdraw(id);
+    uint256 debt = _removeDebt(id);
+    // 3. Perform liquidation and compute the amount of token received.
+    uint256 beforeToken = SafeToken.myBalance(token);
+    IWorker(pos.worker).work(id, pos.owner, debt, data);
+    uint256 back = SafeToken.myBalance(token).sub(beforeToken);
+
+    // 4. Clear position debt and return funds to liquidator and position owner.
+    uint256 left = back > debt ? back - debt : 0;
+    if (left > 0) {
+      _safeUnwrap(pos.owner, left);
+    }
+  }
+
+  /// @dev Kill the given to the position. Liquidate it immediately if killFactor condition is met.
+  /// @param id The position ID to be killed.
+  function kill(uint256 id) external onlyWhitelistedLiqudators accrue(0) nonReentrant {
+    require(fairLaunchPoolId != uint256(-1), "poolId not set");
+    // 1. Verify that the position is eligible for liquidation.
+    Position storage pos = positions[id];
+    require(pos.debtShare > 0, "no debt");
+    // 2. Distribute ALPACAs in FairLaunch to owner
+    _fairLaunchWithdraw(id);
+    uint256 debt = _removeDebt(id);
+    uint256 health = IWorker(pos.worker).health(id);
+    uint256 killFactor = config.killFactor(pos.worker, debt);
+    require(health.mul(killFactor) < debt.mul(10000), "can't liquidate");
+    // 3. Perform liquidation and compute the amount of token received.
+    uint256 beforeToken = SafeToken.myBalance(token);
+    IWorker(pos.worker).liquidate(id);
+    uint256 back = SafeToken.myBalance(token).sub(beforeToken);
+
+    uint256 liquidatorPrize = back.mul(config.getKillBps()).div(10000);
+    uint256 tresauryFees = back.mul(config.getKillTreasuryBps()).div(10000);
+    uint256 prize = liquidatorPrize.add(tresauryFees);
+    uint256 rest = back.sub(prize);
+    // 4. Clear position debt and return funds to liquidator and position owner.
+    if (liquidatorPrize > 0) {
+      _safeUnwrap(msg.sender, liquidatorPrize);
+    }
+
+    if (tresauryFees > 0) {
+      _safeUnwrap(config.getTreasuryAddr(), tresauryFees);
+    }
+
+    uint256 left = rest > debt ? rest - debt : 0;
+    if (left > 0) {
+      _safeUnwrap(pos.owner, left);
+    }
+
+    emit Kill(id, msg.sender, pos.owner, health, debt, prize, left);
+  }
+
+  /// @dev Internal function to add the given debt value to the given position.
+  function _addDebt(uint256 id, uint256 debtVal) internal {
+    Position storage pos = positions[id];
+    uint256 debtShare = debtValToShare(debtVal);
+    pos.debtShare = pos.debtShare.add(debtShare);
+    vaultDebtShare = vaultDebtShare.add(debtShare);
+    vaultDebtVal = vaultDebtVal.add(debtVal);
+    emit AddDebt(id, debtShare);
+  }
+
+  /// @dev Internal function to clear the debt of the given position. Return the debt value.
+  function _removeDebt(uint256 id) internal returns (uint256) {
+    Position storage pos = positions[id];
+    uint256 debtShare = pos.debtShare;
+    if (debtShare > 0) {
+      uint256 debtVal = debtShareToVal(debtShare);
+      pos.debtShare = 0;
+      vaultDebtShare = vaultDebtShare.sub(debtShare);
+      vaultDebtVal = vaultDebtVal.sub(debtVal);
+      emit RemoveDebt(id, debtShare);
+      return debtVal;
+    } else {
+      return 0;
+    }
+  }
+
+  /// @dev Update bank configuration to a new address. Must only be called by owner.
+  /// @param _config The new configurator address.
+  function updateConfig(IVaultConfig _config) external onlyOwner {
+    config = _config;
+  }
+
+  function setFairLaunchPoolId(uint256 _poolId) external onlyOwner {
+    SafeToken.safeApprove(debtToken, config.getFairLaunchAddr(), uint256(-1));
+    fairLaunchPoolId = _poolId;
+  }
+
+  /// @dev Withdraw BaseToken reserve for underwater positions to the given address.
+  /// @param to The address to transfer BaseToken to.
+  /// @param value The number of BaseToken tokens to withdraw. Must not exceed `reservePool`.
+  function withdrawReserve(address to, uint256 value) external onlyOwner nonReentrant {
+    reservePool = reservePool.sub(value);
+    SafeToken.safeTransfer(token, to, value);
+  }
+
+  /// @dev Reduce BaseToken reserve, effectively giving them to the depositors.
+  /// @param value The number of BaseToken reserve to reduce.
+  function reduceReserve(uint256 value) external onlyOwner {
+    reservePool = reservePool.sub(value);
+  }
+
+  /// @dev Fallback function to accept BNB.
+  receive() external payable {}
+}

--- a/contracts/6/protocol/workers/waultswap/WaultSwapWorker02.sol
+++ b/contracts/6/protocol/workers/waultswap/WaultSwapWorker02.sol
@@ -319,17 +319,12 @@ contract WaultSwapWorker02 is OwnableUpgradeSafe, ReentrancyGuardUpgradeSafe, IW
         .add(userBaseToken);
   }
 
-  /// @dev Liquidate the given position by converting it to BaseToken and return back to caller.
-  /// @param id The position ID to perform liquidation
-  function liquidate(uint256 id) external override onlyOperator nonReentrant {
-    // 1. Convert the position back to LP tokens and use liquidate strategy.
-    _removeShare(id);
-    lpToken.transfer(address(liqStrat), lpToken.balanceOf(address(this)));
-    liqStrat.execute(address(0), 0, abi.encode(0));
-    // 2. Return all available BaseToken back to the operator.
-    uint256 liquidatedAmount = actualBaseTokenBalance();
-    baseToken.safeTransfer(msg.sender, liquidatedAmount);
-    emit Liquidate(id, liquidatedAmount);
+  /// @notice Liquidate the given position by converting it to BaseToken and return back to caller.
+  /// @dev As AIP4.2 is running, not allow to liquidate
+  function liquidate(
+    uint256 /* id */
+  ) external override onlyOperator {
+    revert("aip4.2");
   }
 
   /// @dev Some portion of a bounty from reinvest will be sent to beneficialVault to increase the size of totalToken.

--- a/contracts/8.11/protocol/strategies/waultswap/StrategyOracleLiquidate.sol
+++ b/contracts/8.11/protocol/strategies/waultswap/StrategyOracleLiquidate.sol
@@ -133,7 +133,8 @@ contract StrategyOracleLiquidate is OwnableUpgradeable, ReentrancyGuardUpgradeab
       calBaseFromLiquiditySource(address(_baseToken), address(_farmingToken), _farmBasePrice, _farmingTokenBalance)
     );
     uint256 _baseTokenBalance = _baseToken.balanceOf(address(this));
-    if (_baseTokenBalance - _debt < _minBaseToken) revert StrategyOracleLiquidate_Slippage();
+    if (_debt <= _baseTokenBalance)
+      if (_baseTokenBalance - _debt < _minBaseToken) revert StrategyOracleLiquidate_Slippage();
     // 5. Return base token back to the worker
     _baseToken.safeTransfer(msg.sender, _baseToken.balanceOf(address(this)));
     // 6. Reset approval

--- a/deploy/exec/vault/upgrade/vault.ts
+++ b/deploy/exec/vault/upgrade/vault.ts
@@ -4,6 +4,7 @@ import { ethers, upgrades } from "hardhat";
 import { getConfig } from "../../../entities/config";
 import { TimelockEntity } from "../../../entities";
 import { FileService, TimelockService } from "../../../services";
+import { getDeployer } from "../../../../utils/deployer-helper";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   /*
@@ -23,7 +24,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const config = getConfig();
 
   const timelockTransactions: Array<TimelockEntity.Transaction> = [];
-  const [deployer] = await ethers.getSigners();
+  const deployer = await getDeployer();
   const toBeUpgradedVaults = TARGETED_VAULTS.map((tv) => {
     const vault = config.Vaults.find((v) => tv == v.symbol);
     if (vault === undefined) {

--- a/package.json
+++ b/package.json
@@ -271,7 +271,6 @@
     "deploy:fantom_mainnetfork:workers:config:set-beneficial-vault-config-workers03": "hardhat --network fantom_mainnetfork deploy --no-compile --reset --tags SetBeneficialBuybackFieldsWorkers03",
     "deploy:fantom_mainnetfork:workers:config:set-reinvest-config-workers03": "hardhat --network fantom_mainnetfork deploy --no-compile --reset --tags SetReinvestConfigWorkers03",
     "deploy:fantom_mainnetfork:workers:config:set-treasury-config-workers03": "hardhat --network fantom_mainnetfork deploy --no-compile --reset --tags SetTreasuryFieldsWorkers03",
-
     "deploy:fantom_mainnet:oracles:config:add-price-source-chainlink2": "hardhat --network fantom_mainnet deploy --no-compile --reset --tags AddSourceChainlinkPriceOracle2",
     "deploy:fantom_mainnet:delta-neutral-oracle:deploy:delta-neutral-oracle": "hardhat --network fantom_mainnet deploy --no-compile --reset --tags DeltaNeutralOracle",
     "deploy:fantom_mainnet:delta-neutral-vault-config:deploy:delta-neutral-vault-config": "hardhat --network fantom_mainnet deploy --no-compile --reset --tags DeltaNeutralVaultConfig",
@@ -281,9 +280,7 @@
     "deploy:fantom_mainnet:delta-neutral-worker:config:set-whitelist-callers": "hardhat --network fantom_mainnet deploy --no-compile --reset --tags DeltaNeutralWorkerSetWhitelistCallers",
     "deploy:fantom_mainnet:vault-config:config:set-whitelisted-callers": "hardhat --network fantom_mainnet deploy --no-compile --reset --tags SetWhitelistedCallers",
     "deploy:fantom_mainnet:delta-neutral-vault:config:init-positions": "hardhat --network fantom_mainnet deploy --no-compile --reset --tags DeltaNeutralVaultInitPositions",
-
-
-    "fork":"hardhat console --no-compile --network fantom_mainnetfork",
+    "fork": "hardhat console --no-compile --network fantom_mainnetfork",
     "mainnet": "hardhat console --no-compile --network mainnet",
     "ethereum": "hardhat console --no-compile --network ethereum",
     "test:case": "mocha --require hardhat/register --file test/integrations/protocol/delta-neutral/DeltaNeutralVault.test.ts --extension ts -g",
@@ -373,6 +370,7 @@
     "test:strategyOracleMinimize": "hardhat test --no-compile ./test/integrations/protocol/strategies/waultswap/StrategyOracleMinimize.test.ts",
     "test:strategyOracleLiquidate": "hardhat test --no-compile ./test/integrations/protocol/strategies/waultswap/StrategyOracleLiquidate.test.ts",
     "test:revenue-treasury": "hardhat test --no-compile ./test/integrations/protocol/RevenueTreasury.test.ts",
+    "test:vault42_wault": "hardhat test --no-compile ./test/integrations/protocol/workers/waultswap/VaultAip42_WaultSwapWorker02.test.ts",
     "test": "hardhat test --no-compile",
     "testnet": "hardhat console --no-compile --network testnet",
     "fantom_testnet": "hardhat console --no-compile --network fantom_testnet",
@@ -389,7 +387,6 @@
     "solhint": "./node_modules/.bin/solhint -f table contracts/**/*.sol",
     "prettier:solidity": "./node_modules/.bin/prettier --write contracts/**/*.sol",
     "mainnet-fork": "hardhat node --show-stack-traces --config hardhat.config.8.10.forking.ts"
-    
   },
   "devDependencies": {
     "@chainlink/contracts": "^0.1.7",

--- a/test/helpers/deploy.ts
+++ b/test/helpers/deploy.ts
@@ -135,6 +135,7 @@ import {
   TShare,
   DeltaNeutralSpookyWorker03__factory,
   DeltaNeutralSpookyWorker03,
+  VaultAip42,
 } from "../../typechain";
 import * as TimeHelpers from "../helpers/time";
 
@@ -616,7 +617,8 @@ export class DeployHelper {
     wbnb: MockWBNB,
     vaultConfig: IVaultConfig,
     fairlaunchAddress: string,
-    btoken: MockERC20
+    btoken: MockERC20,
+    vaultVersion = "Vault"
   ): Promise<[Vault, SimpleVaultConfig, WNativeRelayer]> {
     const WNativeRelayer = (await ethers.getContractFactory(
       "WNativeRelayer",
@@ -651,7 +653,7 @@ export class DeployHelper {
     ])) as DebtToken;
     await debtToken.deployed();
 
-    const Vault = (await ethers.getContractFactory("Vault", this.deployer)) as Vault__factory;
+    const Vault = (await ethers.getContractFactory(vaultVersion, this.deployer)) as Vault__factory;
     const btokenSymbol = await btoken.symbol();
     const vault = (await upgrades.deployProxy(Vault, [
       simpleVaultConfig.address,
@@ -689,9 +691,30 @@ export class DeployHelper {
 
     // Set add FairLaunch poool and set fairLaunchPoolId for Vault
     await fairlaunch.addPool(1, await vault.debtToken(), false);
-    await vault.setFairLaunchPoolId(0);
+    await vault.setFairLaunchPoolId((await fairlaunch.poolLength()).sub(1));
 
     return [vault, simpleVaultConfig, wNativeRelayer];
+  }
+
+  public async deployVaultAip42(
+    wbnb: MockWBNB,
+    vaultConfig: IVaultConfig,
+    fairlaunch: FairLaunch,
+    btoken: MockERC20
+  ): Promise<[VaultAip42, SimpleVaultConfig, WNativeRelayer]> {
+    const [vault, simpleVaultConfig, wNativeRelayer] = await this._deployVault(
+      wbnb,
+      vaultConfig,
+      fairlaunch.address,
+      btoken,
+      "VaultAip42"
+    );
+
+    // Set add FairLaunch poool and set fairLaunchPoolId for Vault
+    await fairlaunch.addPool(1, await vault.debtToken(), true);
+    await vault.setFairLaunchPoolId((await fairlaunch.poolLength()).sub(1));
+
+    return [vault as unknown as VaultAip42, simpleVaultConfig, wNativeRelayer];
   }
 
   public async deployMiniFLVault(

--- a/test/integrations/protocol/workers/waultswap/VaultAip42_WaultSwapWorker02.test.ts
+++ b/test/integrations/protocol/workers/waultswap/VaultAip42_WaultSwapWorker02.test.ts
@@ -1,0 +1,686 @@
+import { ethers, network, upgrades, waffle } from "hardhat";
+import { BigNumber } from "ethers";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import {
+  AlpacaToken,
+  WaultSwapToken,
+  DebtToken,
+  FairLaunch,
+  FairLaunch__factory,
+  MockERC20,
+  MockERC20__factory,
+  MockWBNB,
+  WaultSwapFactory,
+  WexMaster,
+  WexMaster__factory,
+  PancakePair,
+  PancakePair__factory,
+  WaultSwapRouter,
+  WaultSwapRestrictedStrategyAddBaseTokenOnly,
+  WaultSwapRestrictedStrategyLiquidate,
+  WaultSwapWorker02,
+  WaultSwapWorker02__factory,
+  SimpleVaultConfig,
+  WNativeRelayer,
+  StrategyOracleMinimize,
+  StrategyOracleLiquidate,
+  StrategyOracleMinimize__factory,
+  SimplePriceOracle__factory,
+  SimplePriceOracle,
+  StrategyOracleLiquidate__factory,
+  VaultAip42,
+  VaultAip42__factory,
+} from "../../../../../typechain";
+import * as TimeHelpers from "../../../../helpers/time";
+import { SwapHelper } from "../../../../helpers/swap";
+import { DeployHelper } from "../../../../helpers/deploy";
+import { Worker02Helper } from "../../../../helpers/worker";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+chai.use(solidity);
+const { expect } = chai;
+
+describe("VaultAip42 - WaultSwap02", () => {
+  const FOREVER = "2000000000";
+  const ALPACA_BONUS_LOCK_UP_BPS = 7000;
+  const ALPACA_REWARD_PER_BLOCK = ethers.utils.parseEther("5000");
+  const WEX_REWARD_PER_BLOCK = ethers.utils.parseEther("0.076");
+  const REINVEST_BOUNTY_BPS = "100"; // 1% reinvest bounty
+  const RESERVE_POOL_BPS = "1000"; // 10% reserve pool
+  const KILL_PRIZE_BPS = "1000"; // 10% Kill prize
+  const INTEREST_RATE = "0"; // 0% per year for easy testing
+  const MIN_DEBT_SIZE = ethers.utils.parseEther("1"); // 1 BTOKEN min debt size
+  const WORK_FACTOR = "7000";
+  const KILL_FACTOR = "8000";
+  const DISCOUNT_FACTOR = ethers.BigNumber.from("9500");
+  const DEPLOYER = "0xC44f82b07Ab3E691F826951a6E335E1bC1bB0B51";
+  const KILL_TREASURY_BPS = "100";
+  const POOL_ID = 0;
+
+  /// WaultSwap-related instance(s)
+  let factory: WaultSwapFactory;
+  let router: WaultSwapRouter;
+
+  let wbnb: MockWBNB;
+  let lp: PancakePair;
+
+  /// Token-related instance(s)
+  let baseToken: MockERC20;
+  let farmToken: MockERC20;
+  let wex: WaultSwapToken;
+  let debtToken: DebtToken;
+
+  /// Price-oracle instance(s)
+  let priceOracle: SimplePriceOracle;
+
+  /// Strategy-ralted instance(s)
+  let addStrat: WaultSwapRestrictedStrategyAddBaseTokenOnly;
+  let liqStrat: WaultSwapRestrictedStrategyLiquidate;
+  let oracleMinimizeStrat: StrategyOracleMinimize;
+  let oracleLiquidateStrat: StrategyOracleLiquidate;
+
+  /// Vault-related instance(s)
+  let simpleVaultConfig: SimpleVaultConfig;
+  let wNativeRelayer: WNativeRelayer;
+  let vault: VaultAip42;
+
+  /// FairLaunch-related instance(s)
+  let fairLaunch: FairLaunch;
+  let alpacaToken: AlpacaToken;
+
+  /// WexMaster-related instance(s)
+  let wexMaster: WexMaster;
+  let waultSwapWorker: WaultSwapWorker02;
+
+  // Accounts
+  let deployer: SignerWithAddress;
+  let alice: SignerWithAddress;
+  let bob: SignerWithAddress;
+  let eve: SignerWithAddress;
+
+  let deployerAddress: string;
+  let aliceAddress: string;
+  let bobAddress: string;
+  let eveAddress: string;
+
+  // Contract Signer
+  let baseTokenAsAlice: MockERC20;
+  let baseTokenAsBob: MockERC20;
+
+  let vaultAsAlice: VaultAip42;
+  let vaultAsBob: VaultAip42;
+  let vaultAsEve: VaultAip42;
+
+  // Test Helper
+  let swapHelper: SwapHelper;
+  let workerHelper: Worker02Helper;
+
+  async function fixture() {
+    await network.provider.request({
+      method: "hardhat_impersonateAccount",
+      params: ["0xc44f82b07ab3e691f826951a6e335e1bc1bb0b51"],
+    });
+    deployer = await ethers.getSigner("0xc44f82b07ab3e691f826951a6e335e1bc1bb0b51");
+    [alice, bob, eve] = await ethers.getSigners();
+    // Seed deployer with some native
+    await alice.sendTransaction({ to: deployer.address, value: ethers.utils.parseEther("100") });
+    [deployerAddress, aliceAddress, bobAddress, eveAddress] = await Promise.all([
+      deployer.getAddress(),
+      alice.getAddress(),
+      bob.getAddress(),
+      eve.getAddress(),
+    ]);
+    const deployHelper = new DeployHelper(deployer);
+
+    wbnb = await deployHelper.deployWBNB();
+    [factory, router, wex, wexMaster] = await deployHelper.deployWaultSwap(wbnb, WEX_REWARD_PER_BLOCK);
+    [baseToken, farmToken] = await deployHelper.deployBEP20([
+      {
+        name: "BTOKEN",
+        symbol: "BTOKEN",
+        decimals: "18",
+        holders: [
+          { address: deployerAddress, amount: ethers.utils.parseEther("1000") },
+          { address: aliceAddress, amount: ethers.utils.parseEther("1000") },
+          { address: bobAddress, amount: ethers.utils.parseEther("1000") },
+        ],
+      },
+      {
+        name: "FTOKEN",
+        symbol: "FTOKEN",
+        decimals: "18",
+        holders: [
+          { address: deployerAddress, amount: ethers.utils.parseEther("1000") },
+          { address: aliceAddress, amount: ethers.utils.parseEther("1000") },
+          { address: bobAddress, amount: ethers.utils.parseEther("1000") },
+        ],
+      },
+    ]);
+    [alpacaToken, fairLaunch] = await deployHelper.deployAlpacaFairLaunch(
+      ALPACA_REWARD_PER_BLOCK,
+      ALPACA_BONUS_LOCK_UP_BPS,
+      132,
+      137
+    );
+    [vault, simpleVaultConfig, wNativeRelayer] = await deployHelper.deployVaultAip42(
+      wbnb,
+      {
+        minDebtSize: MIN_DEBT_SIZE,
+        interestRate: INTEREST_RATE,
+        reservePoolBps: RESERVE_POOL_BPS,
+        killPrizeBps: KILL_PRIZE_BPS,
+        killTreasuryBps: KILL_TREASURY_BPS,
+        killTreasuryAddress: DEPLOYER,
+      },
+      fairLaunch,
+      baseToken
+    );
+    [addStrat, liqStrat] = await deployHelper.deployWaultSwapStrategies(router, vault, wbnb, wNativeRelayer);
+
+    const SimplePriceOracle = new SimplePriceOracle__factory(deployer);
+    priceOracle = (await upgrades.deployProxy(SimplePriceOracle, [deployer.address])) as SimplePriceOracle;
+
+    const StrategyOracleMinimize = new StrategyOracleMinimize__factory(deployer);
+    oracleMinimizeStrat = (await upgrades.deployProxy(StrategyOracleMinimize, [
+      "WaultSwap Oracle Minimize Strategy",
+      router.address,
+      wNativeRelayer.address,
+      priceOracle.address,
+      deployer.address,
+      DISCOUNT_FACTOR,
+    ])) as StrategyOracleMinimize;
+
+    const StrategyOracleLiquidate = new StrategyOracleLiquidate__factory(deployer);
+    oracleLiquidateStrat = (await upgrades.deployProxy(StrategyOracleLiquidate, [
+      "WaultSwap Oracle Liquidate Strategy",
+      router.address,
+      priceOracle.address,
+      deployer.address,
+      DISCOUNT_FACTOR,
+    ])) as StrategyOracleLiquidate;
+
+    await baseToken.approve(oracleMinimizeStrat.address, ethers.constants.MaxUint256);
+    await baseToken.approve(oracleLiquidateStrat.address, ethers.constants.MaxUint256);
+
+    /// Setup BTOKEN-FTOKEN pair on WaultSwap
+    await factory.createPair(baseToken.address, farmToken.address);
+    lp = PancakePair__factory.connect(await factory.getPair(farmToken.address, baseToken.address), deployer);
+    await lp.deployed();
+
+    // Add lp to masterChef's pool
+    await wexMaster.add(1, lp.address, true);
+
+    /// Setup WaultSwapWorker02
+    const WaultSwapWorker02 = (await ethers.getContractFactory(
+      "WaultSwapWorker02",
+      deployer
+    )) as WaultSwapWorker02__factory;
+    waultSwapWorker = (await upgrades.deployProxy(WaultSwapWorker02, [
+      vault.address,
+      baseToken.address,
+      wexMaster.address,
+      router.address,
+      POOL_ID,
+      addStrat.address,
+      liqStrat.address,
+      REINVEST_BOUNTY_BPS,
+      DEPLOYER,
+      [wex.address, wbnb.address, baseToken.address],
+      "0",
+    ])) as WaultSwapWorker02;
+    await waultSwapWorker.deployed();
+
+    await simpleVaultConfig.setWorker(waultSwapWorker.address, true, true, WORK_FACTOR, KILL_FACTOR, true, true);
+    await waultSwapWorker.setStrategyOk([oracleMinimizeStrat.address, oracleLiquidateStrat.address], true);
+    await waultSwapWorker.setReinvestorOk([eveAddress], true);
+    await waultSwapWorker.setTreasuryConfig(DEPLOYER, REINVEST_BOUNTY_BPS);
+    await addStrat.setWorkersOk([waultSwapWorker.address], true);
+    await oracleMinimizeStrat.setWorkersOk([waultSwapWorker.address], true);
+    await liqStrat.setWorkersOk([waultSwapWorker.address], true);
+    await oracleLiquidateStrat.setWorkersOk([waultSwapWorker.address], true);
+    await simpleVaultConfig.setApprovedAddStrategy([addStrat.address], true);
+    await simpleVaultConfig.setWhitelistedLiquidators([aliceAddress, eveAddress], true);
+
+    // Initiate swapHelper
+    swapHelper = new SwapHelper(factory.address, router.address, BigNumber.from(998), BigNumber.from(1000), deployer);
+    workerHelper = new Worker02Helper(waultSwapWorker.address, wexMaster.address);
+
+    // Deployer adds 0.1 FTOKEN + 1 BTOKEN
+    await baseToken.approve(router.address, ethers.utils.parseEther("1"));
+    await farmToken.approve(router.address, ethers.utils.parseEther("0.1"));
+    await router.addLiquidity(
+      baseToken.address,
+      farmToken.address,
+      ethers.utils.parseEther("1"),
+      ethers.utils.parseEther("0.1"),
+      "0",
+      "0",
+      deployerAddress,
+      FOREVER
+    );
+
+    // Deployer adds 0.1 WEX + 1 NATIVE
+    await wex.approve(router.address, ethers.utils.parseEther("1"));
+    await router.addLiquidityETH(wex.address, ethers.utils.parseEther("0.1"), "0", "0", deployerAddress, FOREVER, {
+      value: ethers.utils.parseEther("1"),
+    });
+
+    // Deployer adds 1 BTOKEN + 1 NATIVE
+    await baseToken.approve(router.address, ethers.utils.parseEther("1"));
+    await router.addLiquidityETH(baseToken.address, ethers.utils.parseEther("1"), "0", "0", deployerAddress, FOREVER, {
+      value: ethers.utils.parseEther("1"),
+    });
+
+    // Deployer adds 1 FTOKEN + 1 NATIVE
+    await farmToken.approve(router.address, ethers.utils.parseEther("1"));
+    await router.addLiquidityETH(farmToken.address, ethers.utils.parseEther("1"), "0", "0", deployerAddress, FOREVER, {
+      value: ethers.utils.parseEther("1"),
+    });
+
+    // Contract signer
+    baseTokenAsAlice = MockERC20__factory.connect(baseToken.address, alice);
+    baseTokenAsBob = MockERC20__factory.connect(baseToken.address, bob);
+
+    vaultAsAlice = VaultAip42__factory.connect(vault.address, alice);
+    vaultAsBob = VaultAip42__factory.connect(vault.address, bob);
+    vaultAsEve = VaultAip42__factory.connect(vault.address, eve);
+  }
+
+  beforeEach(async () => {
+    await waffle.loadFixture(fixture);
+  });
+
+  context("when user uses LYF", async () => {
+    context("#kill", async () => {
+      context("when the positions are liquidatable", async () => {
+        it("should liquidate user position correctly", async () => {
+          // Bob deposits 20 BTOKEN
+          await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther("20"));
+          await vaultAsBob.deposit(ethers.utils.parseEther("20"));
+
+          // Position#1: Alice borrows 10 BTOKEN loan
+          await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther("10"));
+          await vaultAsAlice.work(
+            0,
+            waultSwapWorker.address,
+            ethers.utils.parseEther("10"),
+            ethers.utils.parseEther("10"),
+            "0", // max return = 0, don't return BTOKEN to the debt
+            ethers.utils.defaultAbiCoder.encode(
+              ["address", "bytes"],
+              [addStrat.address, ethers.utils.defaultAbiCoder.encode(["uint256"], ["0"])]
+            )
+          );
+
+          await farmToken.mint(deployerAddress, ethers.utils.parseEther("100"));
+          await farmToken.approve(router.address, ethers.utils.parseEther("100"));
+
+          // Price swing 10%
+          // Add more token to the pool equals to sqrt(10*((0.1)**2) / 9) - 0.1 = 0.005409255338945984, (0.1 is the balance of token in the pool)
+          await router.swapExactTokensForTokens(
+            ethers.utils.parseEther("0.005409255338945984"),
+            "0",
+            [farmToken.address, baseToken.address],
+            deployerAddress,
+            FOREVER
+          );
+          await expect(vaultAsEve.kill("1")).to.be.revertedWith("can't liquidate");
+
+          // Price swing 70%
+          // Add more token to the pool equals to
+          // sqrt(10*((0.10540925533894599)**2) / 3) - 0.10540925533894599 = 0.08704083439092929
+          // (0.10540925533894599 is the balance of token in the pool)
+          await router.swapExactTokensForTokens(
+            ethers.utils.parseEther("0.08704083439092929"),
+            "0",
+            [farmToken.address, baseToken.address],
+            deployerAddress,
+            FOREVER
+          );
+
+          // Now position can be liquidated but AIP4.2 is running
+          await expect(vaultAsEve.kill("1")).revertedWith("aip4.2");
+        });
+      });
+    });
+
+    context("#forceClose", async () => {
+      const borrowAmount = ethers.utils.parseEther("10");
+      let stages: Record<string, BigNumber>;
+      let accumLp: BigNumber;
+
+      beforeEach(async () => {
+        stages = {};
+
+        // Bob deposits 20 BTOKEN
+        await baseTokenAsBob.approve(vault.address, ethers.utils.parseEther("20"));
+        await vaultAsBob.deposit(ethers.utils.parseEther("20"));
+
+        // Position#1: Alice borrows 10 BTOKEN loan
+        await baseTokenAsAlice.approve(vault.address, ethers.utils.parseEther("10"));
+        await vaultAsAlice.work(
+          0,
+          waultSwapWorker.address,
+          ethers.utils.parseEther("10"),
+          borrowAmount,
+          "0", // max return = 0, don't return BTOKEN to the debt
+          ethers.utils.defaultAbiCoder.encode(
+            ["address", "bytes"],
+            [addStrat.address, ethers.utils.defaultAbiCoder.encode(["uint256"], ["0"])]
+          )
+        );
+
+        [accumLp] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+        console.log(accumLp);
+
+        stages["aliceOpenPosition"] = await TimeHelpers.latestBlockNumber();
+
+        await priceOracle.setPrices(
+          [baseToken.address, farmToken.address],
+          [farmToken.address, baseToken.address],
+          [ethers.utils.parseEther("0.1"), ethers.utils.parseEther("10")]
+        );
+      });
+
+      context("when caller is not a deployer", async () => {
+        it("should revert", async () => {
+          await expect(vaultAsEve.forceClose("1", "0x")).to.be.revertedWith("!D");
+        });
+      });
+
+      context("when caller is a deployer", async () => {
+        context("when position is not underwater", async () => {
+          context("when use oracle minimize", async () => {
+            context("when debt < received base token", async () => {
+              it("should work", async () => {
+                const [path, reinvestPath] = await Promise.all([
+                  waultSwapWorker.getPath(),
+                  waultSwapWorker.getReinvestPath(),
+                ]);
+                await swapHelper.loadReserves(path);
+                await swapHelper.loadReserves(reinvestPath);
+
+                const [workerLpBefore] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+                const aliceBaseBefore = await baseToken.balanceOf(aliceAddress);
+                const aliceFarmBefore = await farmToken.balanceOf(aliceAddress);
+
+                await vault.forceClose(
+                  "1",
+                  ethers.utils.defaultAbiCoder.encode(
+                    ["address", "bytes"],
+                    [oracleMinimizeStrat.address, ethers.utils.defaultAbiCoder.encode(["uint256"], ["0"])]
+                  )
+                );
+
+                const aliceBaseAfter = await baseToken.balanceOf(aliceAddress);
+                const aliceFarmAfter = await farmToken.balanceOf(aliceAddress);
+                stages["afterForceCloseAlicePosition"] = await TimeHelpers.latestBlockNumber();
+                const [workerLpAfter] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+                let totalRewards = swapHelper.computeTotalRewards(
+                  workerLpBefore,
+                  WEX_REWARD_PER_BLOCK,
+                  stages["afterForceCloseAlicePosition"].sub(stages["aliceOpenPosition"])
+                );
+                let reinvestFees = totalRewards.mul(REINVEST_BOUNTY_BPS).div(10000);
+                let reinvestLeft = totalRewards.sub(reinvestFees);
+
+                let reinvestAmts = await swapHelper.computeSwapExactTokensForTokens(reinvestLeft, reinvestPath, true);
+                let reinvestBtoken = reinvestAmts[reinvestAmts.length - 1];
+                let [reinvestLp, debrisBtoken, debrisFtoken] = await swapHelper.computeOneSidedOptimalLp(
+                  reinvestBtoken,
+                  path
+                );
+                accumLp = accumLp.add(reinvestLp);
+
+                let [receivedBaseToken, receivedFarmToken] = await swapHelper.computeRemoveLiquidiy(
+                  baseToken.address,
+                  farmToken.address,
+                  accumLp
+                );
+
+                const positionInfo = await vault.positions(1);
+                expect(workerLpAfter).to.be.eq(0);
+                expect(aliceBaseAfter.sub(aliceBaseBefore)).to.be.eq(receivedBaseToken.sub(borrowAmount));
+                expect(aliceFarmAfter.sub(aliceFarmBefore)).to.be.eq(receivedFarmToken);
+                expect(positionInfo.debtShare).to.be.eq(0);
+              });
+            });
+
+            context("when debt > received base token", async () => {
+              it("should work", async () => {
+                await farmToken.mint(deployerAddress, ethers.utils.parseEther("100"));
+                await farmToken.approve(router.address, ethers.utils.parseEther("100"));
+
+                // Price swing 66%
+                // Add more token to the pool equals to sqrt(100*((0.1)**2) / 34) - 0.1 = 0.0714986,
+                // (0.1 is the balance of token in the pool)
+                await router.swapExactTokensForTokens(
+                  ethers.utils.parseEther("0.0714986"),
+                  "0",
+                  [farmToken.address, baseToken.address],
+                  deployerAddress,
+                  FOREVER
+                );
+
+                const [path, reinvestPath] = await Promise.all([
+                  waultSwapWorker.getPath(),
+                  waultSwapWorker.getReinvestPath(),
+                ]);
+                await swapHelper.loadReserves(path);
+                await swapHelper.loadReserves(reinvestPath);
+
+                const [workerLpBefore] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+                const aliceBaseBefore = await baseToken.balanceOf(aliceAddress);
+                const aliceFarmBefore = await farmToken.balanceOf(aliceAddress);
+                const liquidityBaseBefore = await baseToken.balanceOf(deployerAddress);
+                const liquidityFarmBefore = await farmToken.balanceOf(deployerAddress);
+
+                await vault.forceClose(
+                  "1",
+                  ethers.utils.defaultAbiCoder.encode(
+                    ["address", "bytes"],
+                    [oracleMinimizeStrat.address, ethers.utils.defaultAbiCoder.encode(["uint256"], ["0"])]
+                  )
+                );
+
+                const aliceBaseAfter = await baseToken.balanceOf(aliceAddress);
+                const aliceFarmAfter = await farmToken.balanceOf(aliceAddress);
+                const liquidityBaseAfter = await baseToken.balanceOf(deployerAddress);
+                const liquidityFarmAfter = await farmToken.balanceOf(deployerAddress);
+
+                stages["afterForceCloseAlicePosition"] = await TimeHelpers.latestBlockNumber();
+                const [workerLpAfter] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+                let totalRewards = swapHelper.computeTotalRewards(
+                  workerLpBefore,
+                  WEX_REWARD_PER_BLOCK,
+                  stages["afterForceCloseAlicePosition"].sub(stages["aliceOpenPosition"])
+                );
+                let reinvestFees = totalRewards.mul(REINVEST_BOUNTY_BPS).div(10000);
+                let reinvestLeft = totalRewards.sub(reinvestFees);
+
+                let reinvestAmts = await swapHelper.computeSwapExactTokensForTokens(reinvestLeft, reinvestPath, true);
+                let reinvestBtoken = reinvestAmts[reinvestAmts.length - 1];
+                let [reinvestLp] = await swapHelper.computeOneSidedOptimalLp(reinvestBtoken, path);
+                accumLp = accumLp.add(reinvestLp);
+
+                let [receivedBaseToken, receivedFarmToken] = await swapHelper.computeRemoveLiquidiy(
+                  baseToken.address,
+                  farmToken.address,
+                  accumLp
+                );
+
+                const positionInfo = await vault.positions(1);
+                const farmOraclePriceData = await priceOracle.getPrice(farmToken.address, baseToken.address);
+                const baseNeed = borrowAmount.sub(receivedBaseToken);
+                const farmToDeduct = baseNeed
+                  .mul(ethers.constants.WeiPerEther)
+                  .div(farmOraclePriceData.price.mul(DISCOUNT_FACTOR).div(10000));
+
+                expect(workerLpAfter).to.be.eq(0);
+                expect(aliceBaseAfter.sub(aliceBaseBefore)).to.be.eq(0);
+                expect(aliceFarmAfter.sub(aliceFarmBefore)).to.be.eq(receivedFarmToken.sub(farmToDeduct));
+                expect(liquidityBaseBefore.sub(liquidityBaseAfter)).to.be.eq(baseNeed);
+                expect(liquidityFarmAfter.sub(liquidityFarmBefore)).to.be.eq(farmToDeduct);
+                expect(positionInfo.debtShare).to.be.eq(0);
+              });
+            });
+          });
+
+          context("when use oracle liquidate", async () => {
+            context("when position is not underwater", async () => {
+              it("should work", async () => {
+                const [path, reinvestPath] = await Promise.all([
+                  waultSwapWorker.getPath(),
+                  waultSwapWorker.getReinvestPath(),
+                ]);
+                await swapHelper.loadReserves(path);
+                await swapHelper.loadReserves(reinvestPath);
+
+                const [workerLpBefore] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+                const aliceBaseBefore = await baseToken.balanceOf(aliceAddress);
+                const aliceFarmBefore = await farmToken.balanceOf(aliceAddress);
+                const liquidityBaseBefore = await baseToken.balanceOf(deployerAddress);
+                const liquidityFarmBefore = await farmToken.balanceOf(deployerAddress);
+
+                await vault.forceClose(
+                  "1",
+                  ethers.utils.defaultAbiCoder.encode(
+                    ["address", "bytes"],
+                    [oracleLiquidateStrat.address, ethers.utils.defaultAbiCoder.encode(["uint256"], ["0"])]
+                  )
+                );
+
+                const aliceBaseAfter = await baseToken.balanceOf(aliceAddress);
+                const aliceFarmAfter = await farmToken.balanceOf(aliceAddress);
+                const liquidityBaseAfter = await baseToken.balanceOf(deployerAddress);
+                const liquidityFarmAfter = await farmToken.balanceOf(deployerAddress);
+
+                stages["afterForceCloseAlicePosition"] = await TimeHelpers.latestBlockNumber();
+                const [workerLpAfter] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+                let totalRewards = swapHelper.computeTotalRewards(
+                  workerLpBefore,
+                  WEX_REWARD_PER_BLOCK,
+                  stages["afterForceCloseAlicePosition"].sub(stages["aliceOpenPosition"])
+                );
+                let reinvestFees = totalRewards.mul(REINVEST_BOUNTY_BPS).div(10000);
+                let reinvestLeft = totalRewards.sub(reinvestFees);
+
+                let reinvestAmts = await swapHelper.computeSwapExactTokensForTokens(reinvestLeft, reinvestPath, true);
+                let reinvestBtoken = reinvestAmts[reinvestAmts.length - 1];
+                let [reinvestLp, debrisBtoken, debrisFtoken] = await swapHelper.computeOneSidedOptimalLp(
+                  reinvestBtoken,
+                  path
+                );
+                accumLp = accumLp.add(reinvestLp);
+
+                let [receivedBaseToken, receivedFarmToken] = await swapHelper.computeRemoveLiquidiy(
+                  baseToken.address,
+                  farmToken.address,
+                  accumLp
+                );
+
+                const positionInfo = await vault.positions(1);
+                const farmOraclePriceData = await priceOracle.getPrice(farmToken.address, baseToken.address);
+                const baseFromLiquiditySource = receivedFarmToken
+                  .mul(farmOraclePriceData.price)
+                  .mul(DISCOUNT_FACTOR)
+                  .div(10000)
+                  .div(ethers.constants.WeiPerEther);
+                receivedBaseToken = receivedBaseToken.add(baseFromLiquiditySource);
+
+                expect(workerLpAfter).to.be.eq(0);
+                expect(aliceBaseAfter.sub(aliceBaseBefore)).to.be.eq(receivedBaseToken.sub(borrowAmount));
+                expect(aliceFarmAfter.sub(aliceFarmBefore)).to.be.eq(0);
+                expect(liquidityBaseBefore.sub(liquidityBaseAfter)).to.be.eq(baseFromLiquiditySource);
+                expect(liquidityFarmAfter.sub(liquidityFarmBefore)).to.be.eq(receivedFarmToken);
+                expect(positionInfo.debtShare).to.be.eq(0);
+              });
+            });
+
+            context("when position is underwater", async () => {
+              it("should work", async () => {
+                await farmToken.mint(deployerAddress, ethers.utils.parseEther("100"));
+                await farmToken.approve(router.address, ethers.utils.parseEther("100"));
+
+                // Price swing 95%
+                // Add more token to the pool equals to sqrt(100*((0.1)**2) / 5) - 0.1 = 0.347214,
+                // (0.1 is the balance of token in the pool)
+                await router.swapExactTokensForTokens(
+                  ethers.utils.parseEther("0.347214"),
+                  "0",
+                  [farmToken.address, baseToken.address],
+                  deployerAddress,
+                  FOREVER
+                );
+
+                const [path, reinvestPath] = await Promise.all([
+                  waultSwapWorker.getPath(),
+                  waultSwapWorker.getReinvestPath(),
+                ]);
+                await swapHelper.loadReserves(path);
+                await swapHelper.loadReserves(reinvestPath);
+
+                const [workerLpBefore] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+                const aliceBaseBefore = await baseToken.balanceOf(aliceAddress);
+                const aliceFarmBefore = await farmToken.balanceOf(aliceAddress);
+                const liquidityBaseBefore = await baseToken.balanceOf(deployerAddress);
+                const liquidityFarmBefore = await farmToken.balanceOf(deployerAddress);
+
+                await vault.forceClose(
+                  "1",
+                  ethers.utils.defaultAbiCoder.encode(
+                    ["address", "bytes"],
+                    [oracleLiquidateStrat.address, ethers.utils.defaultAbiCoder.encode(["uint256"], ["0"])]
+                  )
+                );
+
+                const aliceBaseAfter = await baseToken.balanceOf(aliceAddress);
+                const aliceFarmAfter = await farmToken.balanceOf(aliceAddress);
+                const liquidityBaseAfter = await baseToken.balanceOf(deployerAddress);
+                const liquidityFarmAfter = await farmToken.balanceOf(deployerAddress);
+
+                stages["afterForceCloseAlicePosition"] = await TimeHelpers.latestBlockNumber();
+                const [workerLpAfter] = await wexMaster.userInfo(POOL_ID, waultSwapWorker.address);
+                let totalRewards = swapHelper.computeTotalRewards(
+                  workerLpBefore,
+                  WEX_REWARD_PER_BLOCK,
+                  stages["afterForceCloseAlicePosition"].sub(stages["aliceOpenPosition"])
+                );
+                let reinvestFees = totalRewards.mul(REINVEST_BOUNTY_BPS).div(10000);
+                let reinvestLeft = totalRewards.sub(reinvestFees);
+
+                let reinvestAmts = await swapHelper.computeSwapExactTokensForTokens(reinvestLeft, reinvestPath, true);
+                let reinvestBtoken = reinvestAmts[reinvestAmts.length - 1];
+                let [reinvestLp] = await swapHelper.computeOneSidedOptimalLp(reinvestBtoken, path);
+                accumLp = accumLp.add(reinvestLp);
+
+                let [receivedBaseToken, receivedFarmToken] = await swapHelper.computeRemoveLiquidiy(
+                  baseToken.address,
+                  farmToken.address,
+                  accumLp
+                );
+
+                const positionInfo = await vault.positions(1);
+                const farmOraclePriceData = await priceOracle.getPrice(farmToken.address, baseToken.address);
+                const baseFromLiquiditySource = receivedFarmToken
+                  .mul(farmOraclePriceData.price)
+                  .mul(DISCOUNT_FACTOR)
+                  .div(10000)
+                  .div(ethers.constants.WeiPerEther);
+                receivedBaseToken = receivedBaseToken.add(baseFromLiquiditySource);
+
+                expect(workerLpAfter).to.be.eq(0);
+                expect(aliceBaseAfter.sub(aliceBaseBefore)).to.be.eq(0);
+                expect(aliceFarmAfter.sub(aliceFarmBefore)).to.be.eq(0);
+                expect(liquidityBaseBefore.sub(liquidityBaseAfter)).to.be.eq(baseFromLiquiditySource);
+                expect(liquidityFarmAfter.sub(liquidityFarmBefore)).to.be.eq(receivedFarmToken);
+                expect(positionInfo.debtShare).to.be.eq(0);
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
Supporting AIP4.2 (https://snapshot.org/#/alpacafinance.eth/proposal/0xb4f4a29393b7918116766b1ba84781d677941934b705fb4c20f5047c69c55fd0) by creating a new routine called `forceClose` on a special vault implementation, VaultAip42.sol. The `forceClose` routine will allow the deployer to force close WaultSwap positions to eliminate the bad debt risks from remaining WaultSwap positions.

This PR also included a new version of WaultSwapWorker02 to disable liquidation on the WaultSwap positions as there could be a chance that one position get forced close and it shallow up the liquidity depth of the pool which would create a risk of bad debts.

## Why?
To eliminate the bad debt risks from WaultSwap positions.

## ChangeLogs:
- Add `VaultAip42.sol`
- Edit `WaultSwapWorker02`
- Add tests to all changes above
