### PR TITLE
[main][feat]  Assess credit of xALPACA holders

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,7 +403,8 @@
     "mainnet-fork": "hardhat node --show-stack-traces --config hardhat.config.8.10.forking.ts",
     "forge:build": "forge build --sizes --force",
     "forge:test": "forge test",
-    "forge:watch": "forge test -w"
+    "forge:watch": "forge test -w",
+    "test:xalpaca-creditor": "forge test --match-path solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol"
   },
   "devDependencies": {
     "@chainlink/contracts": "^0.1.7",

--- a/solidity/contracts/8.13/interfaces/ICreditor.sol
+++ b/solidity/contracts/8.13/interfaces/ICreditor.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL
+/**
+  ∩~~~~∩ 
+  ξ ･×･ ξ 
+  ξ　~　ξ 
+  ξ　　 ξ 
+  ξ　　 “~～~～〇 
+  ξ　　　　　　 ξ 
+  ξ ξ ξ~～~ξ ξ ξ 
+　 ξ_ξξ_ξ　ξ_ξξ_ξ
+Alpaca Fin Corporation
+*/
+
+pragma solidity 0.8.13;
+
+interface Creditor {
+  function getUserCredit(address _user) external view returns (uint256);
+}

--- a/solidity/contracts/8.13/interfaces/IxALPACA.sol
+++ b/solidity/contracts/8.13/interfaces/IxALPACA.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL
+/**
+  ∩~~~~∩ 
+  ξ ･×･ ξ 
+  ξ　~　ξ 
+  ξ　　 ξ 
+  ξ　　 “~～~～〇 
+  ξ　　　　　　 ξ 
+  ξ ξ ξ~～~ξ ξ ξ 
+　 ξ_ξξ_ξ　ξ_ξξ_ξ
+Alpaca Fin Corporation
+*/
+
+pragma solidity 0.8.13;
+
+interface IxALPACA {
+  function balanceOf(address _user) external view returns (uint256);
+
+  function balanceOfAt(address _user, uint256 _blockNumber) external view returns (uint256);
+
+  function epoch() external view returns (uint256);
+}

--- a/solidity/contracts/8.13/xALPACACreditor.sol
+++ b/solidity/contracts/8.13/xALPACACreditor.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL
+/**
+  ∩~~~~∩ 
+  ξ ･×･ ξ 
+  ξ　~　ξ 
+  ξ　　 ξ 
+  ξ　　 “~～~～〇 
+  ξ　　　　　　 ξ 
+  ξ ξ ξ~～~ξ ξ ξ 
+　 ξ_ξξ_ξ　ξ_ξξ_ξ
+Alpaca Fin Corporation
+*/
+
+pragma solidity 0.8.13;
+
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import { IxALPACA } from "./interfaces/IxALPACA.sol";
+
+contract xALPACACreditor is OwnableUpgradeable {
+  /// @notice Events
+  event Log_SetValuePerxALPACA(address indexed _caller, uint256 _oldValuePerxALPACA, uint256 _newValuePerxALPACA);
+
+  /// @notice Errors
+  error xALPACACreditor_ValueTooHigh();
+
+  /// @notice States
+  IxALPACA public xALPACA;
+  uint256 public valuePerxALPACA;
+
+  function initialize(IxALPACA _xALPACA, uint256 _valuePerxALPACA) external initializer {
+    // sainity check
+    _xALPACA.epoch();
+
+    xALPACA = IxALPACA(_xALPACA);
+    valuePerxALPACA = _valuePerxALPACA;
+  }
+
+  function getUserCredit(address _user) external view returns (uint256) {
+    return (xALPACA.balanceOf(_user) * valuePerxALPACA) / 1e18;
+  }
+
+  function setValuePerxALPACA(uint256 _newValuePerxALPACA) external {
+    if (_newValuePerxALPACA > 1000 * 1e18) {
+      revert xALPACACreditor_ValueTooHigh();
+    }
+
+    uint256 _oldValuePerxALPACA = valuePerxALPACA;
+    valuePerxALPACA = _newValuePerxALPACA;
+
+    emit Log_SetValuePerxALPACA(msg.sender, _oldValuePerxALPACA, _newValuePerxALPACA);
+  }
+}

--- a/solidity/contracts/8.13/xALPACACreditor.sol
+++ b/solidity/contracts/8.13/xALPACACreditor.sol
@@ -29,9 +29,10 @@ contract xALPACACreditor is OwnableUpgradeable {
   uint256 public valuePerxALPACA;
 
   function initialize(IxALPACA _xALPACA, uint256 _valuePerxALPACA) external initializer {
-    // sainity check
+    // sanity check
     _xALPACA.epoch();
 
+    OwnableUpgradeable.__Ownable_init();
     xALPACA = IxALPACA(_xALPACA);
     valuePerxALPACA = _valuePerxALPACA;
   }
@@ -40,7 +41,7 @@ contract xALPACACreditor is OwnableUpgradeable {
     return (xALPACA.balanceOf(_user) * valuePerxALPACA) / 1e18;
   }
 
-  function setValuePerxALPACA(uint256 _newValuePerxALPACA) external {
+  function setValuePerxALPACA(uint256 _newValuePerxALPACA) external onlyOwner {
     if (_newValuePerxALPACA > 1000 * 1e18) {
       revert xALPACACreditor_ValueTooHigh();
     }

--- a/solidity/tests/base/BaseTest.sol
+++ b/solidity/tests/base/BaseTest.sol
@@ -15,6 +15,7 @@ import { TripleSlopeModelLike } from "../interfaces/TripleSlopeModelLike.sol";
 import { DebtTokenLike } from "../interfaces/DebtTokenLike.sol";
 import { SimpleVaultConfigLike } from "../interfaces/SimpleVaultConfigLike.sol";
 import { VaultLike } from "../interfaces/VaultLike.sol";
+import { xALPACACreditorLike } from "../interfaces/xALPACACreditorLike.sol";
 
 // solhint-disable const-name-snakecase
 // solhint-disable no-inline-assembly
@@ -159,5 +160,16 @@ contract BaseTest is DSTest {
       _address := create(0, add(_bytecode, 0x20), mload(_bytecode))
     }
     return TripleSlopeModelLike(_address);
+  }
+
+  function _setupxALPACACreditor(address _xALPACA, uint256 _valuePerxALPACA) internal returns (xALPACACreditorLike) {
+    bytes memory _logicBytecode = abi.encodePacked(vm.getCode("./out/xALPACACreditor.sol/xALPACACreditor.json"));
+    bytes memory _initializer = abi.encodeWithSelector(
+      bytes4(keccak256("initialize(address,uint256)")),
+      _xALPACA,
+      _valuePerxALPACA
+    );
+    address _proxy = _setupUpgradeable(_logicBytecode, _initializer);
+    return xALPACACreditorLike(_proxy);
   }
 }

--- a/solidity/tests/interfaces/xALPACACreditorLike.sol
+++ b/solidity/tests/interfaces/xALPACACreditorLike.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL
+/**
+  ∩~~~~∩ 
+  ξ ･×･ ξ 
+  ξ　~　ξ 
+  ξ　　 ξ 
+  ξ　　 “~～~～〇 
+  ξ　　　　　　 ξ 
+  ξ ξ ξ~～~ξ ξ ξ 
+　 ξ_ξξ_ξ　ξ_ξξ_ξ
+Alpaca Fin Corporation
+*/
+
+pragma solidity >=0.8.4 <0.9.0;
+
+interface xALPACACreditorLike {
+  function getUserCredit(address _user) external view returns (uint256);
+
+  function setValuePerxALPACA(uint256 _newValuePerxALPACA) external;
+}

--- a/solidity/tests/interfaces/xALPACACreditorLike.sol
+++ b/solidity/tests/interfaces/xALPACACreditorLike.sol
@@ -17,4 +17,6 @@ interface xALPACACreditorLike {
   function getUserCredit(address _user) external view returns (uint256);
 
   function setValuePerxALPACA(uint256 _newValuePerxALPACA) external;
+
+  function owner() external view returns (address);
 }

--- a/solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4 <0.9.0;
+
+import { BaseTest, console, xALPACACreditorLike } from "../../base/BaseTest.sol";
+
+import { xALPACACreditor } from "../../../contracts/8.13/xALPACACreditor.sol";
+import { IxALPACA } from "../../../contracts/8.13/interfaces/IxALPACA.sol";
+
+import { mocking } from "../../utils/mocking.sol";
+import { MockContract } from "../../utils/MockContract.sol";
+
+// solhint-disable func-name-mixedcase
+// solhint-disable contract-name-camelcase
+contract xAlpacaCreditor_Test is BaseTest {
+  using mocking for *;
+  uint64 private constant VALUE_PER_XALPACA = 2e18;
+
+  xALPACACreditorLike private _creditor;
+  IxALPACA private _xALPACA;
+
+  address private _userAddress = address(1);
+
+  function setUp() external {
+    _xALPACA = IxALPACA(address(new MockContract()));
+    _xALPACA.epoch.mockv(1);
+    _xALPACA.balanceOf.mockv(_userAddress, 1e18);
+
+    _creditor = _setupxALPACACreditor(address(_xALPACA), VALUE_PER_XALPACA);
+  }
+
+  function testCorrectness_getUserCredit() external {
+    assertEq(_creditor.getUserCredit(_userAddress), 2e18);
+  }
+}

--- a/solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4 <0.9.0;
 
-import { BaseTest, console, xALPACACreditorLike } from "../../base/BaseTest.sol";
+import { BaseTest, console, xALPACACreditorLike, console } from "../../base/BaseTest.sol";
 
 import { xALPACACreditor } from "../../../contracts/8.13/xALPACACreditor.sol";
 import { IxALPACA } from "../../../contracts/8.13/interfaces/IxALPACA.sol";
@@ -39,7 +39,14 @@ contract xAlpacaCreditor_Test is BaseTest {
 
   function testCannotSetValuePerXalpacaMoreThanThreshold() external {
     vm.expectRevert(abi.encodeWithSignature("xALPACACreditor_ValueTooHigh()"));
+
     _creditor.setValuePerxALPACA(10000 ether);
+  }
+
+  function testCannotSetValuePerXalpacaIfNotOwner() external {
+    vm.expectRevert("Ownable: caller is not the owner");
+    vm.prank(ALICE);
+    _creditor.setValuePerxALPACA(100 ether);
   }
 
   function testCanSetValuePerXalpacaLessThanThreshold(uint256 _value) external {

--- a/solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol
@@ -13,7 +13,7 @@ import { MockContract } from "../../utils/MockContract.sol";
 // solhint-disable contract-name-camelcase
 contract xAlpacaCreditor_Test is BaseTest {
   using mocking for *;
-  uint64 private constant VALUE_PER_XALPACA = 2e18;
+  uint64 private constant VALUE_PER_XALPACA = 2 ether;
 
   xALPACACreditorLike private _creditor;
   IxALPACA private _xALPACA;
@@ -23,12 +23,27 @@ contract xAlpacaCreditor_Test is BaseTest {
   function setUp() external {
     _xALPACA = IxALPACA(address(new MockContract()));
     _xALPACA.epoch.mockv(1);
-    _xALPACA.balanceOf.mockv(_userAddress, 1e18);
+    _xALPACA.balanceOf.mockv(_userAddress, 1 ether);
 
     _creditor = _setupxALPACACreditor(address(_xALPACA), VALUE_PER_XALPACA);
   }
 
   function testCorrectness_getUserCredit() external {
-    assertEq(_creditor.getUserCredit(_userAddress), 2e18);
+    assertEq(_creditor.getUserCredit(_userAddress), 2 ether);
+  }
+
+  function testCorrectness_afterUpdateValuePerxALPACA() external {
+    _creditor.setValuePerxALPACA(4 ether);
+    assertEq(_creditor.getUserCredit(_userAddress), 4 ether);
+  }
+
+  function testCannotSetValuePerXalpacaMoreThanThreshold() external {
+    vm.expectRevert(abi.encodeWithSignature("xALPACACreditor_ValueTooHigh()"));
+    _creditor.setValuePerxALPACA(10000e18);
+  }
+
+  function testCanSetValuePerXalpacaLessThanThreshold(uint256 _value) external {
+    vm.assume(_value < 1000 ether);
+    _creditor.setValuePerxALPACA(_value);
   }
 }

--- a/solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/xALPACACreditor.t.sol
@@ -39,7 +39,7 @@ contract xAlpacaCreditor_Test is BaseTest {
 
   function testCannotSetValuePerXalpacaMoreThanThreshold() external {
     vm.expectRevert(abi.encodeWithSignature("xALPACACreditor_ValueTooHigh()"));
-    _creditor.setValuePerxALPACA(10000e18);
+    _creditor.setValuePerxALPACA(10000 ether);
   }
 
   function testCanSetValuePerXalpacaLessThanThreshold(uint256 _value) external {

--- a/solidity/tests/utils/MockContract.sol
+++ b/solidity/tests/utils/MockContract.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+contract MockContract {
+  fallback() external payable {}
+}

--- a/solidity/tests/utils/mocking.sol
+++ b/solidity/tests/utils/mocking.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 < 0.9.0;
+
+/// DEPS
+import { VM } from "./VM.sol";
+
+// mocking library
+library mocking {
+  address private constant HEVM_ADDRESS =
+    address(bytes20(uint160(uint256(keccak256("hevm cheat code")))));
+
+  VM private constant vm = VM(HEVM_ADDRESS);
+
+  // func() => address
+  function mock(function() external returns (address) f, address  returned1)
+    internal
+  {
+    vm.mockCall(
+      f.address,
+      abi.encodeWithSelector(f.selector),
+      abi.encode(returned1)
+    );
+  }
+
+  // func() payable => address
+  function mockp(function () external payable returns (address) f, address  returned1)
+    internal
+  {
+    vm.mockCall(
+      f.address,
+      abi.encodeWithSelector(f.selector),
+      abi.encode(returned1)
+    );
+  }
+
+  // func () view => address
+  function mockv(function () external view returns (address) f, address  returned1)
+    internal
+  {
+    vm.mockCall(
+      f.address,
+      abi.encodeWithSelector(f.selector),
+      abi.encode(returned1)
+    );
+  }
+
+
+  // func(address,address) view => uint256, uint256
+  function mockv(function(address,address) external view returns (uint256, uint256) f, address addr1, address addr2, uint256 returned1, uint256 returned2)
+    internal
+  {
+    vm.mockCall(
+      f.address,
+      abi.encodeWithSelector(f.selector, addr1, addr2),
+      abi.encode(returned1, returned2)
+    );
+  }
+
+    // func(address) view => uint256
+  function mockv(function(address) external view returns (uint256) f, address addr1, uint256 returned1)
+    internal
+  {
+    vm.mockCall(
+      f.address,
+      abi.encodeWithSelector(f.selector, addr1),
+      abi.encode(returned1)
+    );
+  }
+
+    // func () view => uint256
+  function mockv(function () external view returns (uint256) f, uint256  returned1)
+    internal
+  {
+    vm.mockCall(
+      f.address,
+      abi.encodeWithSelector(f.selector),
+      abi.encode(returned1)
+    );
+  }
+}


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
A contract that assess credit line (in usd) per xALPACA that user's holding

## Why?
So that each xALPACA holders can access to private AVs with appropriate credit line

## ChangeLogs:
- xALPACA creditor
- test in Forge
- MockContract for testing
- mocking lib


### Link to story (if available)
ALPACA-4092
