### PR TITLE
[main][feat][ALPACA-4147] add setOracle on DeltaNeutralOracle

### DIFF
--- a/solidity/contracts/8.10/protocol/DeltaNeutralOracle.sol
+++ b/solidity/contracts/8.10/protocol/DeltaNeutralOracle.sol
@@ -27,7 +27,7 @@ contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgrad
   using AlpacaMath for uint256;
 
   /// @dev Events
-  event DeltaNeutralOracle_SetOracle(address _newOracle);
+  event LogSetOracle(address indexed _caller, address _newOracle);
 
   /// @dev Errors
   error DeltaNeutralOracle_InvalidLPAddress();
@@ -81,8 +81,10 @@ contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgrad
   /// @param _oracle oracle address
   function setOracle(address _oracle) external onlyOwner {
     if (_oracle == address(0)) revert DeltaNeutralOracle_InvalidOracleAddress();
+
     chainLinkPriceOracle = IChainLinkPriceOracle(_oracle);
-    emit DeltaNeutralOracle_SetOracle(_oracle);
+
+    emit LogSetOracle(msg.sender, _oracle);
   }
 
   /// @notice get LP price using internal only, return value in 1e18 format

--- a/solidity/contracts/8.10/protocol/DeltaNeutralOracle.sol
+++ b/solidity/contracts/8.10/protocol/DeltaNeutralOracle.sol
@@ -26,8 +26,12 @@ import "../utils/AlpacaMath.sol";
 contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgradeable {
   using AlpacaMath for uint256;
 
+  /// @dev Events
+  event DeltaNeutralOracle_SetOracle(address _newOracle);
+
   /// @dev Errors
   error DeltaNeutralOracle_InvalidLPAddress();
+  error DeltaNeutralOracle_InvalidOracleAddress();
 
   /// @notice An address of chainlink usd token
   address public usd;
@@ -70,6 +74,15 @@ contract DeltaNeutralOracle is IDeltaNeutralOracle, Initializable, OwnableUpgrad
   function getTokenPrice(address _tokenAddress) public view returns (uint256, uint256) {
     (uint256 _price, uint256 _lastTimestamp) = chainLinkPriceOracle.getPrice(_tokenAddress, usd);
     return (_price, _lastTimestamp);
+  }
+
+  /// @notice Set oracle
+  /// @dev Set oracle address. Must be called by owner.
+  /// @param _oracle oracle address
+  function setOracle(address _oracle) external onlyOwner {
+    if (_oracle == address(0)) revert DeltaNeutralOracle_InvalidOracleAddress();
+    chainLinkPriceOracle = IChainLinkPriceOracle(_oracle);
+    emit DeltaNeutralOracle_SetOracle(_oracle);
   }
 
   /// @notice get LP price using internal only, return value in 1e18 format

--- a/test/integrations/protocol/DeltaNeutralOracle.test.ts
+++ b/test/integrations/protocol/DeltaNeutralOracle.test.ts
@@ -532,8 +532,8 @@ describe("DeltaNeutralOracle", () => {
     context("when owner try set new price oracle", async () => {
       it("should correct", async () => {
         await expect(priceOracle.setOracle("0x166f56F2EDa9817cAB77118AE4FCAA0002A17eC7"))
-          .to.be.emit(priceOracle, "DeltaNeutralOracle_SetOracle")
-          .withArgs("0x166f56F2EDa9817cAB77118AE4FCAA0002A17eC7");
+          .to.be.emit(priceOracle, "LogSetOracle")
+          .withArgs(await deployer.getAddress(), "0x166f56F2EDa9817cAB77118AE4FCAA0002A17eC7");
       });
 
       it("should revert when set zero address", async () => {


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
implement setOracle function on DeltaNeutralOracle contract

## Why?
upgrade contract for flexibility to set oracle

## ChangeLogs:
- add setOracle function on DeltaNeutralOracle contract


### Link to story (if available)
ALPACA-4147
