### PR TITLE
[main][feat]: Add executor change to delta neutral config 02

### DIFF
--- a/solidity/contracts/8.13/DeltaNeutralVaultConfig02.sol
+++ b/solidity/contracts/8.13/DeltaNeutralVaultConfig02.sol
@@ -60,6 +60,21 @@ contract DeltaNeutralVaultConfig02 is IDeltaNeutralVaultConfig02, OwnableUpgrade
   event LogSetReinvestPath(address indexed _caller, address[] _reinvestPath);
   event LogSetController(address indexed _caller, address _controller);
 
+  event LogSetExecutor(
+    address indexed _caller,
+    address _depositExecutor,
+    address _withdrawExecutor,
+    address _rebalanceExecutor,
+    address _reinvestExecutor
+  );
+  event LogSetSwapConfig(address indexed _caller, uint256 swapFee, uint256 swapFeeDenom);
+  event LogSetStrategies(
+    address indexed _caller,
+    address partialCloseMinimizeStrategy,
+    address stableAddTwoSideStrategy,
+    address assetAddTwoSideStrategy
+  );
+
   // --- Errors ---
   error DeltaNeutralVaultConfig_LeverageLevelTooLow();
   error DeltaNeutralVaultConfig_TooMuchFee(uint256 _depositFeeBps, uint256 _withdrawalFeeBps, uint256 _mangementFeeBps);
@@ -139,6 +154,21 @@ contract DeltaNeutralVaultConfig02 is IDeltaNeutralVaultConfig02, OwnableUpgrade
 
   // Automated Vault Controller
   address public override controller;
+
+  /// Executor
+  address public depositExecutor;
+  address public withdrawExecutor;
+  address public rebalanceExecutor;
+  address public reinvestExecutor;
+
+  /// swap config
+  uint256 public swapFee;
+  uint256 public swapFeeDenom;
+
+  /// Strategies
+  address public partialCloseMinimizeStrategy;
+  address public stableAddTwoSideStrategy;
+  address public assetAddTwoSideStrategy;
 
   function initialize(
     address _getWrappedNativeAddr,
@@ -366,5 +396,53 @@ contract DeltaNeutralVaultConfig02 is IDeltaNeutralVaultConfig02, OwnableUpgrade
     controller = _controller;
 
     emit LogSetController(msg.sender, _controller);
+  }
+
+  function setExecutor(
+    address _depositExecutor,
+    address _withdrawExecutor,
+    address _rebalanceExecutor,
+    address _reinvestExecutor
+  ) external onlyOwner {
+    depositExecutor = _depositExecutor;
+    withdrawExecutor = _withdrawExecutor;
+    rebalanceExecutor = _rebalanceExecutor;
+    reinvestExecutor = _reinvestExecutor;
+
+    emit LogSetExecutor(msg.sender, _depositExecutor, _withdrawExecutor, _rebalanceExecutor, _reinvestExecutor);
+  }
+
+  /// @notice Return if caller is executor.
+  /// @param _caller caller.
+  function isExecutor(address _caller) external view returns (bool) {
+    return
+      _caller == depositExecutor ||
+      _caller == withdrawExecutor ||
+      _caller == rebalanceExecutor ||
+      _caller == reinvestExecutor;
+  }
+
+  function setSwapConfig(uint256 _swapFee, uint256 _swapFeeDenom) external onlyOwner {
+    swapFee = _swapFee;
+    swapFeeDenom = _swapFeeDenom;
+
+    emit LogSetSwapConfig(msg.sender, _swapFee, _swapFeeDenom);
+  }
+
+  function setStrategies(
+    address _partialCloseMinimizeStrategy,
+    address _stableAddTwoSideStrategy,
+    address _assetAddTwoSideStrategy
+  ) external onlyOwner {
+    partialCloseMinimizeStrategy = _partialCloseMinimizeStrategy;
+    stableAddTwoSideStrategy = _stableAddTwoSideStrategy;
+    assetAddTwoSideStrategy = _assetAddTwoSideStrategy;
+
+    emit LogSetStrategies(
+      msg.sender,
+      _partialCloseMinimizeStrategy,
+      _stableAddTwoSideStrategy,
+      _assetAddTwoSideStrategy
+    );
   }
 }

--- a/solidity/contracts/8.13/interfaces/IDeltaNeutralVaultConfig02.sol
+++ b/solidity/contracts/8.13/interfaces/IDeltaNeutralVaultConfig02.sol
@@ -81,7 +81,39 @@ interface IDeltaNeutralVaultConfig02 {
   /// @dev Return reinvest path
   function getReinvestPath() external view returns (address[] memory);
 
+  /// @dev Return controller address
   function controller() external view returns (address);
 
+  /// @dev Set a new controller
   function setController(address _controller) external;
+
+  /// @dev Return deposit executor
+  function depositExecutor() external view returns (address);
+
+  /// @dev Return withdraw executor
+  function withdrawExecutor() external view returns (address);
+
+  /// @dev Return rebalance executor
+  function rebalanceExecutor() external view returns (address);
+
+  /// @dev Return reinvest executor
+  function reinvestExecutor() external view returns (address);
+
+  /// @dev Return if caller is executor.
+  function isExecutor(address _caller) external view returns (bool);
+
+  /// @dev Return Partial close minimize strategy address
+  function partialCloseMinimizeStrategy() external view returns (address);
+
+  /// @dev Return Stable add two side strategy address
+  function stableAddTwoSideStrategy() external view returns (address);
+
+  /// @dev Return Asset add two side strategy address
+  function assetAddTwoSideStrategy() external view returns (address);
+
+  /// @dev Return swap fee
+  function swapFee() external view returns (uint256);
+
+  /// @dev Return swap fee denom
+  function swapFeeDenom() external view returns (uint256);
 }


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
Add executor configs to the delta neutral config 02

## Why?
To mitigate risk of multiple upgrade or deployment for upcoming change, delta neutral config can be deployed before hand. Note that this relate to https://github.com/alpaca-finance/bsc-alpaca-contract/pull/305 which was implemented in parallel of Limited Access AV feature.

## ChangeLogs:
- DeltaNeutralConfig02
- IDeltaNeutralConfig02


### Link to story (if available)
<!--- Add story URL here -->
