### PR TITLE
[main][chore][alpaca-4333] exclude typechain/index.ts when publish package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@alpaca-finance/alpaca-contract",
   "version": "1.2.32",
   "scripts": {
-    "prepublish": "yarn build",
+    "prepublish": "yarn build && rm ./typechain/index.*",
     "build": "yarn run build:cjs",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "compile5": "hardhat typechain --config hardhat.config.5.ts",


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
Exclude typechain/index.ts when publish package.
## Why?
In short, to optimize package user performance.

Longer version, to avoid the package user to import from `typechain/index.ts`, but instead, "directly imports" from its source file. "Direct import" significantly improve build performance (ex. frontend code) as it would only include what's really needed into the build, comparing to "index import" which would import everything as it compile the whole index file.


### Link to story (if available)
alpaca-4333
<!--- Add story URL here -->
