### PR TITLE
[main][fix]: Fix incorrect credit tracking

### DIFF
--- a/solidity/contracts/8.13/DeltaNeutralVault02.sol
+++ b/solidity/contracts/8.13/DeltaNeutralVault02.sol
@@ -338,9 +338,6 @@ contract DeltaNeutralVault02 is ERC20Upgradeable, ReentrancyGuardUpgradeable, Ow
     // For private vault, deposit value should not exeed credit
     // Check availableCredit from msg.sender since user interact with contract directly
     IController _controller = IController(config.controller());
-    if (address(_controller) != address(0) && _depositValue > _controller.availableCredit(msg.sender)) {
-      revert DeltaNeutralVault_ExceedCredit();
-    }
 
     // Calculate share from the value gain against the total equity before execution of actions
     uint256 _sharesToUser = _valueToShare(
@@ -358,7 +355,12 @@ contract DeltaNeutralVault02 is ERC20Upgradeable, ReentrancyGuardUpgradeable, Ow
     _outstandingCheck(_outstandingBefore, _outstanding());
 
     // Deduct credit from msg.sender regardless of the _shareReceiver.
-    if (address(_controller) != address(0)) _controller.onDeposit(msg.sender, _sharesToUser);
+    if (address(_controller) != address(0)) {
+      _controller.onDeposit(msg.sender, _sharesToUser);
+      if (_controller.totalCredit(msg.sender) < _controller.usedCredit(msg.sender)) {
+        revert DeltaNeutralVault_ExceedCredit();
+      }
+    }
 
     emit LogDeposit(msg.sender, _shareReceiver, _sharesToUser, _stableTokenAmount, _assetTokenAmount);
     return _sharesToUser;

--- a/solidity/contracts/8.13/DeltaNeutralVault02.sol
+++ b/solidity/contracts/8.13/DeltaNeutralVault02.sol
@@ -334,10 +334,6 @@ contract DeltaNeutralVault02 is ERC20Upgradeable, ReentrancyGuardUpgradeable, Ow
     PositionInfo memory _positionInfoAfter = positionInfo();
     uint256 _depositValue = _calculateEquityChange(_positionInfoAfter, _positionInfoBefore);
 
-    // For private vault, deposit value should not exeed credit
-    // Check availableCredit from msg.sender since user interact with contract directly
-    IController _controller = IController(config.controller());
-
     // Calculate share from the value gain against the total equity before execution of actions
     uint256 _sharesToUser = _valueToShare(
       _depositValue,
@@ -354,6 +350,7 @@ contract DeltaNeutralVault02 is ERC20Upgradeable, ReentrancyGuardUpgradeable, Ow
     _outstandingCheck(_outstandingBefore, _outstanding());
 
     // Deduct credit from msg.sender regardless of the _shareReceiver.
+    IController _controller = IController(config.controller());
     if (address(_controller) != address(0)) {
       _controller.onDeposit(msg.sender, _sharesToUser);
       // in case after deduction, it violated the credit available, revert the transaction

--- a/solidity/contracts/8.13/DeltaNeutralVault02.sol
+++ b/solidity/contracts/8.13/DeltaNeutralVault02.sol
@@ -158,7 +158,6 @@ contract DeltaNeutralVault02 is ERC20Upgradeable, ReentrancyGuardUpgradeable, Ow
     _;
   }
 
-
   /// @notice Initialize Delta Neutral vault.
   /// @param _name Name.
   /// @param _symbol Symbol.
@@ -357,6 +356,7 @@ contract DeltaNeutralVault02 is ERC20Upgradeable, ReentrancyGuardUpgradeable, Ow
     // Deduct credit from msg.sender regardless of the _shareReceiver.
     if (address(_controller) != address(0)) {
       _controller.onDeposit(msg.sender, _sharesToUser);
+      // in case after deduction, it violated the credit available, revert the transaction
       if (_controller.totalCredit(msg.sender) < _controller.usedCredit(msg.sender)) {
         revert DeltaNeutralVault_ExceedCredit();
       }

--- a/solidity/tests/protocol/private-automated-vault/DeltaNeutralVault02.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/DeltaNeutralVault02.t.sol
@@ -80,7 +80,8 @@ contract DeltaNeutralVault02_Test is BaseTest {
   }
 
   function testCorrectness_DepositShouldWorkIfCreditIsSuffice() external {
-    _controller.availableCredit.mockv(address(this), 100 ether);
+    _controller.totalCredit.mockv(address(this), 100 ether);
+    _controller.usedCredit.mockv(address(this), 0 ether);
 
     uint8[] memory _actions = new uint8[](2);
     uint256[] memory _values = new uint256[](2);
@@ -178,7 +179,8 @@ contract DeltaNeutralVault02_Test is BaseTest {
   }
 
   function testRevert_CantDepositIfNoCredit() external {
-    _controller.availableCredit.mockv(address(this), 0 ether);
+    _controller.totalCredit.mockv(address(this), 0 ether);
+    _controller.usedCredit.mockv(address(this), 100 ether);
 
     uint8[] memory _actions = new uint8[](2);
     uint256[] memory _values = new uint256[](2);
@@ -265,7 +267,8 @@ contract DeltaNeutralVault02_Test is BaseTest {
   }
 
   function initPosition() internal {
-    _controller.availableCredit.mockv(address(this), 100 ether);
+    _controller.totalCredit.mockv(address(this), 100 ether);
+    _controller.usedCredit.mockv(address(this), 0 ether);
     uint8[] memory _actions = new uint8[](2);
     uint256[] memory _values = new uint256[](2);
     bytes[] memory _workDatas = new bytes[](2);

--- a/solidity/tests/protocol/private-automated-vault/DeltaNeutralVault02.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/DeltaNeutralVault02.t.sol
@@ -81,7 +81,7 @@ contract DeltaNeutralVault02_Test is BaseTest {
 
   function testCorrectness_DepositShouldWorkIfCreditIsSuffice() external {
     _controller.totalCredit.mockv(address(this), 100 ether);
-    _controller.usedCredit.mockv(address(this), 0 ether);
+    _controller.usedCredit.mockv(address(this), 100 ether);
 
     uint8[] memory _actions = new uint8[](2);
     uint256[] memory _values = new uint256[](2);


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
Credit calculation will be off by large if the current total share in the vault is small relative to the depositing value 

## Why?
Used credit was assessed after execute function but before minting share. This result in current "deposited" share got inflated in value thus failing the deposit which's not supposed to happened

## ChangeLogs:
Move the logic to calculate used credit to the very end after mint was done.

### Link to story (if available)
<!--- Add story URL here -->
