### PR TITLE
[main] [feat] use LinkList to store privateVaults for efficient retrieval

### DIFF
--- a/solidity/contracts/8.13/AutomatedVaultController.sol
+++ b/solidity/contracts/8.13/AutomatedVaultController.sol
@@ -180,7 +180,7 @@ contract AutomatedVaultController is OwnableUpgradeable {
     userVaultShares[_user][msg.sender] += _shareAmount;
 
     // set user's state
-    _initOrInsert(_user, msg.sender);
+    _initOrInsertUserVaults(_user, msg.sender);
   }
 
   /// @notice update user's automated vault's share from withdrawal
@@ -211,7 +211,7 @@ contract AutomatedVaultController is OwnableUpgradeable {
     return userVaultShares[_user][_vault];
   }
 
-  function _initOrInsert(address _user, address _vault) internal {
+  function _initOrInsertUserVaults(address _user, address _vault) internal {
     // set user's state
     LinkList.List storage _userVaults = userVaults[_user];
     if (_userVaults.getNextOf(LinkList.start) == LinkList.empty) {

--- a/solidity/contracts/8.13/AutomatedVaultController.sol
+++ b/solidity/contracts/8.13/AutomatedVaultController.sol
@@ -211,12 +211,6 @@ contract AutomatedVaultController is OwnableUpgradeable {
     return userVaultShares[_user][_vault];
   }
 
-  function enableCreditForVault(address _vault) external {
-    if (!privateVaults.has(_vault)) revert AutomatedVaultController_Unauthorized();
-
-    _initOrInsert(msg.sender, _vault);
-  }
-
   function _initOrInsert(address _user, address _vault) internal {
     // set user's state
     LinkList.List storage _userVaults = userVaults[_user];

--- a/solidity/contracts/8.13/AutomatedVaultController.sol
+++ b/solidity/contracts/8.13/AutomatedVaultController.sol
@@ -86,10 +86,11 @@ contract AutomatedVaultController is OwnableUpgradeable {
   function usedCredit(address _user) public view returns (uint256) {
     uint256 _total;
     uint256 _privateVaultLength = privateVaults.length();
-    address[] memory _privateVaultsArray = privateVaults.getAll();
+    address _curVault = privateVaults.getNextOf(LinkList.start);
     for (uint8 _i = 0; _i < _privateVaultLength; ) {
-      uint256 _share = userVaultShares[_user][address(_privateVaultsArray[_i])];
-      if (_share != 0) _total += IDeltaNeutralVault(_privateVaultsArray[_i]).shareToValue(_share);
+      uint256 _share = userVaultShares[_user][_curVault];
+      if (_share != 0) _total += IDeltaNeutralVault(_curVault).shareToValue(_share);
+      _curVault = privateVaults.getNextOf(_curVault);
       // uncheck overflow to save gas
       unchecked {
         _i++;

--- a/solidity/contracts/8.13/utils/LinkList.sol
+++ b/solidity/contracts/8.13/utils/LinkList.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.6.12 <0.9.0;
+
+library LinkList {
+  address public constant start = address(1);
+  address public constant end = address(1);
+  address public constant empty = address(0);
+
+  struct List {
+    uint256 llSize;
+    mapping(address => address) next;
+  }
+
+  function init(List storage list) internal returns (List storage) {
+    list.next[start] = end;
+
+    return list;
+  }
+
+  function has(List storage list, address addr) internal view returns (bool) {
+    return list.next[addr] != empty;
+  }
+
+  function add(List storage list, address addr) internal returns (List storage) {
+    require(!has(list, addr), "LinkList::add:: addr is already in the list");
+    list.next[addr] = list.next[start];
+    list.next[start] = addr;
+    list.llSize++;
+
+    return list;
+  }
+
+  function remove(
+    List storage list,
+    address addr,
+    address prevAddr
+  ) internal returns (List storage) {
+    require(has(list, addr), "LinkList::remove:: addr not whitelisted yet");
+    require(list.next[prevAddr] == addr, "LinkList::remove:: wrong prevConsumer");
+    list.next[prevAddr] = list.next[addr];
+    list.next[addr] = empty;
+    list.llSize--;
+
+    return list;
+  }
+
+  function getAll(List storage list) internal view returns (address[] memory) {
+    address[] memory addrs = new address[](list.llSize);
+    address curr = list.next[start];
+    for (uint256 i = 0; curr != end; i++) {
+      addrs[i] = curr;
+      curr = list.next[curr];
+    }
+    return addrs;
+  }
+
+  function getPreviousOf(List storage list, address addr) internal view returns (address) {
+    address curr = list.next[start];
+    require(curr != empty, "LinkList::getPreviousOf:: please init the linkedlist first");
+    for (uint256 i = 0; curr != end; i++) {
+      if (list.next[curr] == addr) return curr;
+      curr = list.next[curr];
+    }
+    return end;
+  }
+
+  function getNextOf(List storage list, address curr) internal view returns (address) {
+    return list.next[curr];
+  }
+
+  function length(List storage list) internal view returns (uint256) {
+    return list.llSize;
+  }
+}

--- a/solidity/contracts/8.13/utils/LinkList.sol
+++ b/solidity/contracts/8.13/utils/LinkList.sol
@@ -23,7 +23,7 @@ library LinkList {
   }
 
   function add(List storage list, address addr) internal returns (List storage) {
-    require(!has(list, addr), "LinkList::add:: addr is already in the list");
+    require(!has(list, addr), "existed");
     list.next[addr] = list.next[start];
     list.next[start] = addr;
     list.llSize++;
@@ -36,8 +36,8 @@ library LinkList {
     address addr,
     address prevAddr
   ) internal returns (List storage) {
-    require(has(list, addr), "LinkList::remove:: addr not whitelisted yet");
-    require(list.next[prevAddr] == addr, "LinkList::remove:: wrong prevConsumer");
+    require(has(list, addr), "!exist");
+    require(list.next[prevAddr] == addr, "wrong prev");
     list.next[prevAddr] = list.next[addr];
     list.next[addr] = empty;
     list.llSize--;
@@ -57,7 +57,7 @@ library LinkList {
 
   function getPreviousOf(List storage list, address addr) internal view returns (address) {
     address curr = list.next[start];
-    require(curr != empty, "LinkList::getPreviousOf:: please init the linkedlist first");
+    require(curr != empty, "!inited");
     for (uint256 i = 0; curr != end; i++) {
       if (list.next[curr] == addr) return curr;
       curr = list.next[curr];

--- a/solidity/contracts/8.13/utils/LinkList.sol
+++ b/solidity/contracts/8.13/utils/LinkList.sol
@@ -3,9 +3,9 @@
 pragma solidity >=0.6.12 <0.9.0;
 
 library LinkList {
-  address public constant start = address(1);
-  address public constant end = address(1);
-  address public constant empty = address(0);
+  address internal constant start = address(1);
+  address internal constant end = address(1);
+  address internal constant empty = address(0);
 
   struct List {
     uint256 llSize;

--- a/solidity/tests/interfaces/AutomatedVaultControllerLike.sol
+++ b/solidity/tests/interfaces/AutomatedVaultControllerLike.sol
@@ -35,4 +35,8 @@ interface AutomatedVaultControllerLike {
   function removePrivateVaults(address[] memory) external;
 
   function setCreditors(address[] memory) external;
+
+  function disableCreditForVault(address _vault) external;
+
+  function enableCreditForVault(address _vault) external;
 }

--- a/solidity/tests/interfaces/AutomatedVaultControllerLike.sol
+++ b/solidity/tests/interfaces/AutomatedVaultControllerLike.sol
@@ -36,7 +36,5 @@ interface AutomatedVaultControllerLike {
 
   function setCreditors(address[] memory) external;
 
-  function disableCreditForVault(address _vault) external;
-
   function enableCreditForVault(address _vault) external;
 }

--- a/solidity/tests/interfaces/AutomatedVaultControllerLike.sol
+++ b/solidity/tests/interfaces/AutomatedVaultControllerLike.sol
@@ -35,6 +35,4 @@ interface AutomatedVaultControllerLike {
   function removePrivateVaults(address[] memory) external;
 
   function setCreditors(address[] memory) external;
-
-  function enableCreditForVault(address _vault) external;
 }

--- a/solidity/tests/interfaces/AutomatedVaultControllerLike.sol
+++ b/solidity/tests/interfaces/AutomatedVaultControllerLike.sol
@@ -30,7 +30,9 @@ interface AutomatedVaultControllerLike {
 
   function getId(address, address) external view returns (bytes32);
 
-  function setPrivateVaults(address[] memory) external;
+  function addPrivateVaults(address[] memory) external;
+
+  function removePrivateVaults(address[] memory) external;
 
   function setCreditors(address[] memory) external;
 }

--- a/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
@@ -139,12 +139,6 @@ contract AutomatedVaultController_Test is BaseTest {
     assertEq(_controller.getUserVaultShares(ALICE, address(_deltaVault1)), 2 ether);
   }
 
-  function testRevert_enableCreditForVaultWithNonPrivateVault() external {
-    vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_Unauthorized()"));
-    vm.prank(ALICE);
-    _controller.enableCreditForVault(address(_deltaVault2));
-  }
-
   function testRevert_onDepositWithNonAuthorizeVault() external {
     vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_Unauthorized()"));
     vm.startPrank(EVE);

--- a/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
@@ -139,6 +139,28 @@ contract AutomatedVaultController_Test is BaseTest {
     assertEq(_controller.getUserVaultShares(ALICE, address(_deltaVault1)), 2 ether);
   }
 
+  function testRevert_disableCreditForVaultWhileOutstanding() external {
+    vm.prank(address(_deltaVault1));
+    _controller.onDeposit(ALICE, 1 ether);
+
+    vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_OutstandingCredit()"));
+    vm.prank(ALICE);
+    _controller.disableCreditForVault(address(_deltaVault1));
+  }
+
+  function testCorrectness_disableCreditForVault() external {
+    vm.startPrank(address(_deltaVault1));
+    _controller.onDeposit(ALICE, 1 ether);
+    _controller.onWithdraw(ALICE, 1 ether);
+    vm.stopPrank();
+
+    vm.startPrank(ALICE);
+    _controller.disableCreditForVault(address(_deltaVault1));
+
+    _controller.enableCreditForVault(address(_deltaVault1));
+    _controller.disableCreditForVault(address(_deltaVault1));
+  }
+
   function testRevert_onDepositWithNonAuthorizeVault() external {
     vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_Unauthorized()"));
     vm.startPrank(EVE);

--- a/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
@@ -139,6 +139,12 @@ contract AutomatedVaultController_Test is BaseTest {
     assertEq(_controller.getUserVaultShares(ALICE, address(_deltaVault1)), 2 ether);
   }
 
+  function testRevert_onDepositWithNonAuthorizeVault() external {
+    vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_Unauthorized()"));
+    vm.startPrank(EVE);
+    _controller.onDeposit(ALICE, 1 ether);
+  }
+
   function testCorrectness_onWithdraw() external {
     // impersonate as delta vault #1
     vm.startPrank(address(_deltaVault1));
@@ -182,18 +188,6 @@ contract AutomatedVaultController_Test is BaseTest {
 
     // usedCredit should be equal to 2(vault#1) + 5(vault#2) = 7 ether
     assertEq(_controller.usedCredit(ALICE), 7 ether);
-  }
-
-  function testCorrectness_getUsedCreditShouldTrackOnlyPrivateVault() external {
-    // Deposit 1 share of some random vault
-    vm.prank(address(1));
-    _controller.onDeposit(ALICE, 1 ether);
-
-    // mock share price, 1 share = 2 usd
-    _deltaVault1.shareToValue.mockv(1 ether, 2 ether);
-
-    // used credit should be 0 since user's currently has no share in private vault
-    assertEq(_controller.usedCredit(ALICE), 0 ether);
   }
 
   function testCorrectness_getAvailableCredit() external {

--- a/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
@@ -161,6 +161,12 @@ contract AutomatedVaultController_Test is BaseTest {
     _controller.disableCreditForVault(address(_deltaVault1));
   }
 
+  function testRevert_enableCreditForVaultWithNonPrivateVault() external {
+    vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_Unauthorized()"));
+    vm.prank(ALICE);
+    _controller.enableCreditForVault(address(_deltaVault2));
+  }
+
   function testRevert_onDepositWithNonAuthorizeVault() external {
     vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_Unauthorized()"));
     vm.startPrank(EVE);

--- a/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
@@ -45,20 +45,36 @@ contract AutomatedVaultController_Test is BaseTest {
     _controller = _setupxAutomatedVaultController(_creditors, _deltaVaults);
   }
 
-  function testCorrectness_setPrivateVault() external {
+  function testCorrectness_addPrivateVault() external {
+    address[] memory _deltaVaults = new address[](1);
+    _deltaVaults[0] = address(_deltaVault2);
+
+    _controller.addPrivateVaults(_deltaVaults);
+  }
+
+  function testCorrectness_removePrivateVault() external {
     address[] memory _deltaVaults = new address[](1);
     _deltaVaults[0] = address(_deltaVault1);
 
-    _controller.setPrivateVaults(_deltaVaults);
+    _controller.removePrivateVaults(_deltaVaults);
   }
 
-  function testRevert_setPrivateVaultFromNonOwner() external {
+  function testRevert_addPrivateVaultFromNonOwner() external {
     address[] memory _deltaVaults = new address[](1);
     _deltaVaults[0] = address(_deltaVault1);
 
     vm.expectRevert("Ownable: caller is not the owner");
     vm.prank(ALICE);
-    _controller.setPrivateVaults(_deltaVaults);
+    _controller.addPrivateVaults(_deltaVaults);
+  }
+
+  function testRevert_removePrivateVaultFromNonOwner() external {
+    address[] memory _deltaVaults = new address[](1);
+    _deltaVaults[0] = address(_deltaVault1);
+
+    vm.expectRevert("Ownable: caller is not the owner");
+    vm.prank(ALICE);
+    _controller.removePrivateVaults(_deltaVaults);
   }
 
   function testCorrectness_setCreditors() external {
@@ -77,12 +93,19 @@ contract AutomatedVaultController_Test is BaseTest {
     _controller.setCreditors(_creditors);
   }
 
-  function testFail_setPrivateVaultWithNonDeltaVault() external {
+  function testFail_addPrivateVaultWithNonDeltaVault() external {
     address[] memory _deltaVaults = new address[](2);
     _deltaVaults[0] = address(_deltaVault1);
     _deltaVaults[1] = address(0);
 
-    _controller.setPrivateVaults(_deltaVaults);
+    _controller.addPrivateVaults(_deltaVaults);
+  }
+
+  function testFail_removePrivateVaultWithNonExistingDeltaVault() external {
+    address[] memory _deltaVaults = new address[](1);
+    _deltaVaults[0] = address(_deltaVault2);
+
+    _controller.removePrivateVaults(_deltaVaults);
   }
 
   function testCorrectness_getTotalCredit() external {
@@ -124,11 +147,10 @@ contract AutomatedVaultController_Test is BaseTest {
 
   function testCorrectness_getUsedCredit() external {
     // set up private vaults
-    address[] memory _deltaVaults = new address[](2);
-    _deltaVaults[0] = address(_deltaVault1);
-    _deltaVaults[1] = address(_deltaVault2);
+    address[] memory _deltaVaults = new address[](1);
+    _deltaVaults[0] = address(_deltaVault2);
 
-    _controller.setPrivateVaults(_deltaVaults);
+    _controller.addPrivateVaults(_deltaVaults);
 
     // Deposit 1 vault#1 share
     vm.prank(address(_deltaVault1));

--- a/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
@@ -139,28 +139,6 @@ contract AutomatedVaultController_Test is BaseTest {
     assertEq(_controller.getUserVaultShares(ALICE, address(_deltaVault1)), 2 ether);
   }
 
-  function testRevert_disableCreditForVaultWhileOutstanding() external {
-    vm.prank(address(_deltaVault1));
-    _controller.onDeposit(ALICE, 1 ether);
-
-    vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_OutstandingCredit()"));
-    vm.prank(ALICE);
-    _controller.disableCreditForVault(address(_deltaVault1));
-  }
-
-  function testCorrectness_disableCreditForVault() external {
-    vm.startPrank(address(_deltaVault1));
-    _controller.onDeposit(ALICE, 1 ether);
-    _controller.onWithdraw(ALICE, 1 ether);
-    vm.stopPrank();
-
-    vm.startPrank(ALICE);
-    _controller.disableCreditForVault(address(_deltaVault1));
-
-    _controller.enableCreditForVault(address(_deltaVault1));
-    _controller.disableCreditForVault(address(_deltaVault1));
-  }
-
   function testRevert_enableCreditForVaultWithNonPrivateVault() external {
     vm.expectRevert(abi.encodeWithSignature("AutomatedVaultController_Unauthorized()"));
     vm.prank(ALICE);

--- a/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
+++ b/solidity/tests/protocol/private-automated-vault/AutomatedVaultController.t.sol
@@ -68,12 +68,28 @@ contract AutomatedVaultController_Test is BaseTest {
     _controller.addPrivateVaults(_deltaVaults);
   }
 
+  function testRevert_addDuplicatePrivateVault() external {
+    address[] memory _deltaVaults = new address[](1);
+    _deltaVaults[0] = address(_deltaVault1);
+
+    vm.expectRevert("existed");
+    _controller.addPrivateVaults(_deltaVaults);
+  }
+
   function testRevert_removePrivateVaultFromNonOwner() external {
     address[] memory _deltaVaults = new address[](1);
     _deltaVaults[0] = address(_deltaVault1);
 
     vm.expectRevert("Ownable: caller is not the owner");
     vm.prank(ALICE);
+    _controller.removePrivateVaults(_deltaVaults);
+  }
+
+  function testRevert_removeNonExistPrivateVault() external {
+    address[] memory _deltaVaults = new address[](1);
+    _deltaVaults[0] = address(_deltaVault2);
+
+    vm.expectRevert("!exist");
     _controller.removePrivateVaults(_deltaVaults);
   }
 


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
This PR introduced a circular linked list as the data structure to store the addresses of Private AV for easy and efficient usage at the `AutomatedVaultController`.

## Why?
To optimize gas usage.

## ChangeLogs:
- Add `LinkList` library
- Use `LinkList` for `privateVaults` in `AutomatedVaultController`


### Link to story (if available)
<!--- Add story URL here -->
