### PR TITLE
[main][fix] modify nft staking contract

### DIFF
--- a/solidity/contracts/8.13/nft-staking/NFTStaking.sol
+++ b/solidity/contracts/8.13/nft-staking/NFTStaking.sol
@@ -144,11 +144,12 @@ contract NFTStaking is INFTStaking, OwnableUpgradeable, ReentrancyGuardUpgradeab
     uint256 _lockUntil
   ) external nonReentrant onlyEOA {
     // Check
+    // reset _lockUntil to be current block timestamp
+    // in case caller want to send current timestamp but less than timestamp with block timestamp.
     _lockUntil = _lockUntil < block.timestamp ? block.timestamp : _lockUntil;
     if (poolInfo[_nftAddress].poolWeight == 0) revert NFTStaking_PoolNotExist();
     bytes32 _depositId = keccak256(abi.encodePacked(_nftAddress, msg.sender, _nftTokenId));
     if (userStakingNFTLockUntil[_depositId] != 0) revert NFTStaking_NFTAlreadyStaked();
-    if (_lockUntil < block.timestamp) revert NFTStaking_InvalidLockPeriod();
     uint256 _lockPeriod = _lockUntil - block.timestamp;
     if (_lockPeriod < poolInfo[_nftAddress].minLockPeriod || _lockPeriod > poolInfo[_nftAddress].maxLockPeriod)
       revert NFTStaking_InvalidLockPeriod();

--- a/solidity/contracts/8.13/nft-staking/NFTStaking.sol
+++ b/solidity/contracts/8.13/nft-staking/NFTStaking.sol
@@ -144,6 +144,7 @@ contract NFTStaking is INFTStaking, OwnableUpgradeable, ReentrancyGuardUpgradeab
     uint256 _lockUntil
   ) external nonReentrant onlyEOA {
     // Check
+    _lockUntil = _lockUntil < block.timestamp ? block.timestamp : _lockUntil;
     if (poolInfo[_nftAddress].poolWeight == 0) revert NFTStaking_PoolNotExist();
     bytes32 _depositId = keccak256(abi.encodePacked(_nftAddress, msg.sender, _nftTokenId));
     if (userStakingNFTLockUntil[_depositId] != 0) revert NFTStaking_NFTAlreadyStaked();
@@ -194,7 +195,7 @@ contract NFTStaking is INFTStaking, OwnableUpgradeable, ReentrancyGuardUpgradeab
     bytes32 _depositId = keccak256(abi.encodePacked(_nftAddress, msg.sender, _nftTokenId));
     uint256 _lockUntil = userStakingNFTLockUntil[_depositId];
     if (_lockUntil == 0) revert NFTStaking_NoNFTStaked();
-    if (userStakingNFTLockUntil[_depositId] < block.timestamp) revert NFTStaking_IsNotExpired();
+    if (userStakingNFTLockUntil[_depositId] > block.timestamp) revert NFTStaking_IsNotExpired();
     userStakingNFTLockUntil[_depositId] = 0;
 
     // Effect

--- a/solidity/tests/NFTStakingTest.t.sol
+++ b/solidity/tests/NFTStakingTest.t.sol
@@ -221,7 +221,7 @@ contract NFTStakingTest is BaseTest {
     mockNFT1.approve(address(nftStaking), 0);
     assertEq(mockNFT1.balanceOf(ALICE), 1);
     vm.expectRevert(NFTStakingLike.NFTStaking_InvalidLockPeriod.selector);
-    nftStaking.stakeNFT(nftAddress1, 0, 2000);
+    nftStaking.stakeNFT(nftAddress1, 0, 1641072801);
     vm.stopPrank();
   }
 


### PR DESCRIPTION
<!--- PLEASE FOLLOW THE GUIDELINE -->

## Description
improve/fix contract function

## Why?
Unstake nft, unlock time expire logic is go wrong
Stake nft, can revert if we try send unlocktime equal with current timestamp but block is mined.

## ChangeLogs:
- `stakeNFT` prevent send past timestamp
- `unstakeNFT` fix logic to check expired
- fix test

### Link to story (if available)
<!--- Add story URL here -->
